### PR TITLE
Some fixes to frame/time computations and shifting

### DIFF
--- a/muxtools/subtitle/sub.py
+++ b/muxtools/subtitle/sub.py
@@ -311,7 +311,7 @@ class SubFile(MuxingFile):
             if target == None and isinstance(sync, str):
                 field = line.name if use_actor_field else line.effect
                 if field.lower().strip() == sync.lower().strip() or line.text.lower().strip() == sync.lower().strip():
-                    target = timedelta_to_frame(line.start, fps)
+                    target = timedelta_to_frame(line.start, fps) + 1
 
         if target == None and isinstance(sync, str):
             msg = f"Syncpoint '{sync}' was not found."
@@ -329,7 +329,7 @@ class SubFile(MuxingFile):
                 sync2 = sync2 or sync
             field = line.name if use_actor_field else line.effect
             if field.lower().strip() == sync2.lower().strip() or line.text.lower().strip() == sync2.lower().strip():
-                second_sync = timedelta_to_frame(line.start, fps)
+                second_sync = timedelta_to_frame(line.start, fps) + 1
                 mergedoc.events.remove(line)
                 break
 
@@ -338,7 +338,7 @@ class SubFile(MuxingFile):
         # Assume the first line to be the second syncpoint if none was found
         if second_sync == None:
             for l in filter(lambda event: event.TYPE != "Comment", sorted_lines):
-                second_sync = timedelta_to_frame(l.start, fps)
+                second_sync = timedelta_to_frame(l.start, fps) + 1
                 break
 
         # Merge lines from file

--- a/muxtools/utils/convert.py
+++ b/muxtools/utils/convert.py
@@ -65,7 +65,7 @@ def timedelta_to_frame(time: timedelta, fps: Fraction | PathLike = Fraction(2400
     """
     if not isinstance(fps, Fraction):
         return _frame_from_timecodes(fps, time)
-    ms = Decimal(time.total_seconds())
+    ms = Decimal(time.total_seconds()).__round__(3)
     fps_dec = _fraction_to_decimal(fps)
 
     return int(ms * fps_dec)

--- a/muxtools/utils/convert.py
+++ b/muxtools/utils/convert.py
@@ -67,8 +67,8 @@ def timedelta_to_frame(time: timedelta, fps: Fraction | PathLike = Fraction(2400
         return _frame_from_timecodes(fps, time)
     ms = Decimal(time.total_seconds()).__round__(3)
     fps_dec = _fraction_to_decimal(fps)
-
-    return int(ms * fps_dec)
+    frame_decimal = ms * fps_dec
+    return frame_decimal.__round__()
 
 
 def frame_to_timedelta(f: int, fps: Fraction | PathLike = Fraction(24000, 1001), compensate: bool = False, rounding: bool = True) -> timedelta:


### PR DESCRIPTION
This does not yet match Aegisub's behavior exactly (the critical cases being ones with timestamps very close to frame boundaries; making this match exactly would require bigger refactors, in particular replacing timedeltas with integer millisecond counts and exactly matching Aegisub's rounding behavior), but it should make the normal cases of syncing/shifting work correctly.