### PR TITLE
log: Add custom exception to be returned from log.error and log.crit

### DIFF
--- a/muxtools/utils/log.py
+++ b/muxtools/utils/log.py
@@ -3,7 +3,12 @@ from rich.logging import RichHandler
 import time
 import inspect
 
-__all__ = ["crit", "debug", "error", "exit", "info", "warn", "logger"]
+__all__ = ["crit", "debug", "error", "exit", "info", "warn", "logger", "LoggingException"]
+
+
+class LoggingException(Exception):
+    """Custom exception returned from log.crit and log.error"""
+
 
 FORMAT = "%(name)s | %(message)s"  #
 logging.basicConfig(format=FORMAT, datefmt="[%X]", handlers=[RichHandler(markup=True, omit_repeated_times=False, show_path=False)])
@@ -19,10 +24,10 @@ def _format_msg(msg: str, caller: any) -> str:
     return msg if caller is None else f"[bold]{caller}:[/] {msg}"
 
 
-def crit(msg: str, caller: any = None) -> Exception:
+def crit(msg: str, caller: any = None) -> LoggingException:
     message = _format_msg(msg, caller)
     logger.critical(message)
-    return Exception(message)
+    return LoggingException(message)
 
 
 def debug(msg: str, caller: any = None):
@@ -46,10 +51,10 @@ def warn(msg: str, caller: any = None, sleep: int = 0):
         time.sleep(sleep)
 
 
-def error(msg: str, caller: any = None) -> Exception:
+def error(msg: str, caller: any = None) -> LoggingException:
     message = _format_msg(msg, caller)
     logger.error(message)
-    return Exception(message)
+    return LoggingException(message)
 
 
 def exit(msg: str, caller: any = None):


### PR DESCRIPTION
## Problem

Currently, it is hard to suppress tracebacks from code that already logs the error and aborts execution via `raise log.error(...)`, without also suppressing tracebacks from _unexpected_ exceptions.

For instance, if the user wants to use a snippet like this:
```py
    try:
        mux(args.episode)
    except:
        log.crit("Fatal error while muxing! Exiting...", main)
        sys.exit(1)
```
_All_ errors will be caught and tracebacks suppressed. This can make debugging quite difficult.

As an example, using this [sample script](https://github.com/Jaded-Encoding-Thaumaturgy/muxtools/files/14230807/test.py.txt) (rename to `test.py`; Github doesn't support .py file upload):

```sh
$ python test.py 03
[01:46:03] CRITICAL muxtools | main: Fatal error while muxing! Exiting...
```
The error becomes obvious when removing the try/except:
```sh
$ python test.py 03
Traceback (most recent call last):
  File ".../test.py", line 29, in <module>
    main()
  File ".../test.py", line 20, in main
    mux(args.episode, args.error)
  File ".../test.py", line 11, in mux
    sync = syncs[episode]
           ~~~~~^^^^^^^^^
KeyError: 3
```

## Solution

This PR makes the `log.error` and `log.crit` functions return a custom `Exception` type, allowing the above snippet to become: 
```py
    try:
        mux(args.episode)
    except log.LoggingException:
        log.crit("Fatal error while muxing! Exiting...", main)
        sys.exit(1)
    except Exception as e:
        log.crit("Fatal error while muxing!", main)
        raise e
```

This way, the "known" issues are logged and still end script execution, but do not produce needless tracebacks, while _unexpected_ errors still give helpful tracebacks:

```sh
$ python test.py -e 1
[01:57:30] ERROR    muxtools | mux: Requested error!
[01:57:30] CRITICAL muxtools | main: Fatal error while muxing! Exiting...

$ python test.py 3
[01:53:58] CRITICAL muxtools | main: Fatal error while muxing!
Traceback (most recent call last):
  File ".../test.py", line 31, in <module>
    main()
  File ".../test.py", line 27, in main
    raise e
  File ".../test.py", line 21, in main
    mux(args.episode, args.error)
  File ".../test.py", line 11, in mux
    sync = syncs[episode]
           ~~~~~^^^^^^^^^
KeyError: 3
```