### PR TITLE
Change globsearch return type

### DIFF
--- a/muxtools/misc/chapters.py
+++ b/muxtools/misc/chapters.py
@@ -42,7 +42,7 @@ class Chapters:
         else:
             # Handle both OGM .txt files and xml files
             if isinstance(chapter_source, GlobSearch):
-                chapter_source = chapter_source.paths[0] if isinstance(chapter_source.paths, list) else chapter_source.paths
+                chapter_source = chapter_source.paths[0]
             chapter_source = chapter_source if isinstance(chapter_source, Path) else Path(chapter_source)
 
             self.chapters = parse_xml(chapter_source) if chapter_source.suffix.lower() == ".xml" else parse_ogm(chapter_source)

--- a/muxtools/utils/glob.py
+++ b/muxtools/utils/glob.py
@@ -6,13 +6,13 @@ __all__ = ["GlobSearch"]
 
 
 class GlobSearch:
-    paths: Path | list[Path] = None
+    paths: list[Path] = []
 
     def __init__(
         self,
         pattern: str,
         allow_multiple: bool = False,
-        dir: PathLike = None,
+        target_dir: PathLike = None,
         recursive: bool = True,
     ) -> None:
         """
@@ -20,25 +20,19 @@ class GlobSearch:
 
         :param pattern:         Glob pattern
         :param allow_multiple:  Will return all file matches if True and only the first if False
-        :param dir:             Directory to run the search in. Defaults to current working dir.
+        :param target_dir:      Directory to run the search in. Defaults to current working dir.
         :param recursive:       Search recursively
         """
 
-        dir = Path(dir) if isinstance(dir, str) else dir
-        if dir is None:
-            dir = Path(os.getcwd()).resolve()
+        target_dir = Path(target_dir) if isinstance(target_dir, str) else target_dir
 
-        search = dir.rglob(pattern) if recursive else dir.glob(pattern)
-        # print(search)
+        if target_dir is None:
+            target_dir = Path(os.getcwd()).resolve()
+
+        search = target_dir.rglob(pattern) if recursive else target_dir.glob(pattern)
+
         for f in search:
-            if allow_multiple:
-                if self.paths:
-                    self.paths.append(f)
-                else:
-                    init: list[Path] = [
-                        f,
-                    ]
-                    self.paths = init
-            else:
-                self.paths = f
+            self.paths.append(f)
+
+            if not allow_multiple:
                 break

--- a/muxtools/utils/glob.py
+++ b/muxtools/utils/glob.py
@@ -12,7 +12,7 @@ class GlobSearch:
         self,
         pattern: str,
         allow_multiple: bool = False,
-        target_dir: PathLike = None,
+        dir: PathLike = None,
         recursive: bool = True,
     ) -> None:
         """
@@ -20,16 +20,16 @@ class GlobSearch:
 
         :param pattern:         Glob pattern
         :param allow_multiple:  Will return all file matches if True and only the first if False
-        :param target_dir:      Directory to run the search in. Defaults to current working dir.
+        :param dir:             Directory to run the search in. Defaults to current working dir.
         :param recursive:       Search recursively
         """
 
-        target_dir = Path(target_dir) if isinstance(target_dir, str) else target_dir
+        dir = Path(dir) if isinstance(dir, str) else dir
 
-        if target_dir is None:
-            target_dir = Path(os.getcwd()).resolve()
+        if dir is None:
+            dir = Path(os.getcwd()).resolve()
 
-        search = target_dir.rglob(pattern) if recursive else target_dir.glob(pattern)
+        search = dir.rglob(pattern) if recursive else dir.glob(pattern)
 
         for f in search:
             self.paths.append(f)


### PR DESCRIPTION
It's a lot nicer if we can always expect a single type to be returned. It makes handling returns a lot easier on any devs. 

This PR changes the return type to always be a list[Path]. It also greatly simplifies some basic logic when looping over the search results.