### PR TITLE
Use VideoTimestamps

### DIFF
--- a/muxtools/audio/extractors.py
+++ b/muxtools/audio/extractors.py
@@ -173,7 +173,7 @@ class FFMpeg(HasExtractor, HasTrimmer):
 
         :param trim:                Can be a single trim or a sequence of trims.
         :param trim_use_ms:         Will use milliseconds instead of frame numbers
-        :param fps:                 Fps fraction that will be used for the conversion. Also accepts a timecode (v2) file.
+        :param fps:                 Fps fraction that will be used for the conversion. Also accepts a timecode (v2, v4) file.
         :param preserve_delay:      Will preserve existing container delay
         :param num_frames:          Total number of frames used for calculations
         :param output:              Custom output. Can be a dir or a file.
@@ -367,7 +367,7 @@ class Sox(Trimmer):
     :param trim:                List of Trims or a single Trim, which is a Tuple of two frame numbers or milliseconds
     :param preserve_delay:      Keeps existing container delay if True
     :param trim_use_ms:         Will use milliseconds instead of frame numbers
-    :param fps:                 The fps fraction used for the calculations. Also accepts a timecode (v2) file.
+    :param fps:                 The fps fraction used for the calculations. Also accepts a timecode (v2, v4) file.
     :param num_frames:          Total number of frames used for calculations
     :param output:              Custom output. Can be a dir or a file.
                                 Do not specify an extension unless you know what you're doing.

--- a/muxtools/audio/extractors.py
+++ b/muxtools/audio/extractors.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from fractions import Fraction
 from typing import Sequence
 from pathlib import Path
+from video_timestamps import TimeType
 import os
 import re
 
@@ -17,7 +18,7 @@ from ..utils.files import get_absolute_track
 from ..utils.types import Trim, PathLike, TrackType
 from ..utils.env import get_temp_workdir, run_commandline, communicate_stdout
 from ..utils.subprogress import run_cmd_pb, ProgressBarConfig
-from ..utils.convert import frame_to_timedelta, format_timedelta, frame_to_ms
+from ..utils.convert import frame_to_ms, format_timedelta
 
 __all__ = ["Eac3to", "Sox", "FFMpeg", "MkvExtract"]
 
@@ -208,13 +209,13 @@ class FFMpeg(HasExtractor, HasTrimmer):
                 if self.trim_use_ms:
                     arg += f" -ss {format_timedelta(timedelta(milliseconds=trim[0]))}"
                 else:
-                    arg += f" -ss {format_timedelta(frame_to_timedelta(trim[0], self.fps))}"
+                    arg += f" -ss {format_timedelta(timedelta(milliseconds=frame_to_ms(trim[0], TimeType.EXACT, self.fps, False)))}"
             if trim[1] is not None and trim[1] != 0:
                 end_frame = self.num_frames + trim[1] if trim[1] < 0 else trim[1]
                 if self.trim_use_ms:
                     arg += f" -to {format_timedelta(timedelta(milliseconds=trim[1]))}"
                 else:
-                    arg += f" -to {format_timedelta(frame_to_timedelta(end_frame, self.fps))}"
+                    arg += f" -to {format_timedelta(timedelta(milliseconds=frame_to_ms(end_frame, TimeType.EXACT, self.fps, False)))}"
             return arg
 
         def trim_audio(self, input: AudioFile, quiet: bool = True) -> AudioFile:
@@ -248,7 +249,7 @@ class FFMpeg(HasExtractor, HasTrimmer):
                 args.append(str(out.resolve()))
                 if not run_commandline(args, quiet):
                     if tr[0] and lossy:
-                        ms = tr[0] if self.trim_use_ms else frame_to_ms(tr[0], self.fps)
+                        ms = tr[0] if self.trim_use_ms else frame_to_ms(tr[0], TimeType.EXACT, self.fps, False)
                         cont_delay = self._calc_delay(ms, ainfo.num_samples(), getattr(minfo, "sampling_rate", 48000))
                         debug(f"Additional delay of {cont_delay} ms will be applied to fix remaining sync", self)
                         if self.preserve_delay:
@@ -386,7 +387,7 @@ class Sox(Trimmer):
         if self.trim_use_ms:
             return abs(val) / 1000
         else:
-            return frame_to_timedelta(abs(val), self.fps).total_seconds()
+            return frame_to_ms(abs(val), TimeType.EXACT, self.fps, False) / 1000
 
     def trim_audio(self, input: AudioFile, quiet: bool = True) -> AudioFile:
         import sox

--- a/muxtools/functions.py
+++ b/muxtools/functions.py
@@ -33,7 +33,7 @@ def do_audio(
     :param fileIn:          Input file
     :param track:           Audio track number
     :param trims:           Frame ranges to trim and/or combine, e.g. (24, -24) or [(24, 500), (700, 900)]
-    :param fps:             FPS Fraction used for the conversion to time. Also accepts a timecode (v2) file.
+    :param fps:             FPS Fraction used for the conversion to time. Also accepts a timecode (v2, v4) file.
     :param num_frames:      Total number of frames, used for negative numbers in trims
     :param extractor:       Tool used to extract the audio
     :param trimmer:         Tool used to trim the audio

--- a/muxtools/misc/chapters.py
+++ b/muxtools/misc/chapters.py
@@ -32,7 +32,7 @@ class Chapters:
         Convenience class for chapters
 
         :param chapter_source:      Input either txt with ogm chapters, xml or (a list of) self defined chapters.
-        :param fps:                 Needed for timestamp convertion. Assumes 24000/1001 by default. Also accepts a timecode (v2) file.
+        :param fps:                 Needed for timestamp convertion. Assumes 24000/1001 by default. Also accepts a timecode (v2, v4) file.
         :param _print:              Prints chapters after parsing and after trimming.
         """
         self.fps = fps
@@ -205,7 +205,7 @@ class Chapters:
         Extract chapters from an ass file or a SubFile.
 
         :param file:            Input ass file or SubFile
-        :param fps:             FPS passed to the chapter class for further operations. Also accepts a timecode (v2) file.
+        :param fps:             FPS passed to the chapter class for further operations. Also accepts a timecode (v2, v4) file.
         :param use_actor_field: Uses the actor field instead of the effect field for identification.
         :param markers:         Markers to check for.
         :param _print:          Prints the chapters after parsing
@@ -251,7 +251,7 @@ class Chapters:
         Extract chapters from mkv.
 
         :param file:            Input mkv file
-        :param fps:             FPS passed to the chapter class for further operations. Also accepts a timecode (v2) file.
+        :param fps:             FPS passed to the chapter class for further operations. Also accepts a timecode (v2, v4) file.
         :param _print:          Prints the chapters after parsing
         """
         caller = "Chapters.from_mkv"

--- a/muxtools/subtitle/sub.py
+++ b/muxtools/subtitle/sub.py
@@ -299,7 +299,7 @@ class SubFile(BaseSubFile):
 
         This does not currently exactly reproduce the aegisub behaviour but it should have the same effect.
 
-        :param fps:             The fps fraction used for conversions. Also accepts a timecode (v2) file.
+        :param fps:             The fps fraction used for conversions. Also accepts a timecode (v2, v4) file.
         :param allowed_styles:  A list of style names this will run on. Will run on every line if None.
         """
 
@@ -328,7 +328,7 @@ class SubFile(BaseSubFile):
         :param sync:            Can be None to not adjust timing at all, an int for a frame number or a string for a syncpoint name.
         :param sync2:           The syncpoint you want to use for the second file.
                                 This is needed if you specified a frame for sync and still want to use a specific syncpoint.
-        :param fps:             The fps used for time calculations. Also accepts a timecode (v2) file.
+        :param fps:             The fps used for time calculations. Also accepts a timecode (v2, v4) file.
         :param use_actor_field: Checks the actor field instead of effect for the names if True.
         :param no_error:        Don't error and warn instead if syncpoint not found.
         :param sort_lines:      Sort the lines by the starting timestamp.
@@ -649,7 +649,7 @@ class SubFile(BaseSubFile):
         Shifts all lines by any frame number.
 
         :param frames:              Number of frames to shift by
-        :param fps:                 FPS needed for the timing calculations. Also accepts a timecode (v2) file.
+        :param fps:                 FPS needed for the timing calculations. Also accepts a timecode (v2, v4) file.
         :param delete_before_zero:  Delete lines that would be before 0 after shifting.
         """
 
@@ -704,7 +704,7 @@ class SubFile(BaseSubFile):
         :param file:            Input srt file
         :param an8_all_caps:    Automatically an8 every full caps line with over 7 characters because they're usually signs.
         :param style_all_caps:  Also set the style of these lines to "Sign" wether it exists or not.
-        :param fps:             FPS needed for the time conversion. Also accepts a timecode (v2) file.
+        :param fps:             FPS needed for the time conversion. Also accepts a timecode (v2, v4) file.
         :param encoding:        Encoding used to read the file. Defaults to UTF8.
         """
         caller = "SubFile.from_srt"

--- a/muxtools/utils/convert.py
+++ b/muxtools/utils/convert.py
@@ -29,15 +29,6 @@ def mpls_timestamp_to_timedelta(timestamp: int) -> timedelta:
     return timedelta(seconds=float(seconds))
 
 
-def _frame_from_timecodes(timecodes: PathLike, time: timedelta) -> int:
-    timecode_file = ensure_path_exists(timecodes, _frame_from_timecodes)
-    # Subtract 0.5 from timecodes to ensure correct behavior even with small rounding errors
-    # (A timedelta of 42ms should belong to frame [42, 83) with a timecode list [0, 42, 83, ...])
-    parsed = [(float(x) - 0.5) / 1000 for x in open(timecode_file, "r").read().splitlines()[1:]]
-
-    return len([t for t in parsed if t < time.total_seconds()]) - 1
-
-
 def ms_to_frame(
     ms: int, time_type: TimeType, time_scale: Fraction, fps: Fraction | PathLike = Fraction(24000, 1001), rounding_method: RoundingMethod = RoundingMethod.ROUND
 ) -> int:

--- a/muxtools/utils/convert.py
+++ b/muxtools/utils/convert.py
@@ -38,7 +38,7 @@ def ms_to_frame(
     :param ms:                  The time in millisecond.
     :param time_type:           The time type.
     :param time_scale:          The time scale.
-    :param fps:                 A Fraction containing fps_num and fps_den. Also accepts a timecode (v1, v2, v4) file.
+    :param fps:                 A Fraction containing fps_num and fps_den. Also accepts a timecode (v2, v4) file.
     :param rounding_method:     If you want to be compatible with mkv, use RoundingMethod.ROUND else RoundingMethod.FLOOR.
                                 For more information, see the documentation of [timestamps](https://github.com/moi15moi/VideoTimestamps/blob/578373a5b83402d849d0e83518da7549edf8e03d/video_timestamps/abc_timestamps.py#L13-L26)
     :return:                    The resulting frame number.

--- a/muxtools/utils/convert.py
+++ b/muxtools/utils/convert.py
@@ -29,16 +29,6 @@ def mpls_timestamp_to_timedelta(timestamp: int) -> timedelta:
     return timedelta(seconds=float(seconds))
 
 
-def _timedelta_from_timecodes(timecodes: PathLike, frame: int) -> timedelta:
-    timecode_file = ensure_path_exists(timecodes, _timedelta_from_timecodes)
-    parsed = [float(x) / 1000 for x in open(timecode_file, "r").read().splitlines()[1:]]
-    if len(parsed) <= frame:
-        raise error(f"Frame {frame} is out of range for the given timecode file!", _timedelta_from_timecodes)
-
-    target = timedelta(seconds=parsed[frame])
-    return target
-
-
 def _frame_from_timecodes(timecodes: PathLike, time: timedelta) -> int:
     timecode_file = ensure_path_exists(timecodes, _frame_from_timecodes)
     # Subtract 0.5 from timecodes to ensure correct behavior even with small rounding errors

--- a/muxtools/utils/convert.py
+++ b/muxtools/utils/convert.py
@@ -17,10 +17,6 @@ __all__: list[str] = [
 ]
 
 
-def _fraction_to_decimal(f: Fraction) -> Decimal:
-    return Decimal(f.numerator) / Decimal(f.denominator)
-
-
 def mpls_timestamp_to_timedelta(timestamp: int) -> timedelta:
     """
     Converts a mpls timestamp (from BDMV Playlist files) to a timedelta.

--- a/muxtools/utils/parsing.py
+++ b/muxtools/utils/parsing.py
@@ -1,10 +1,12 @@
 import re
 import os
 import subprocess
+from datetime import timedelta
 from pathlib import Path
 from fractions import Fraction
 from typing import Any
 from pyparsebluray import mpls
+from video_timestamps import TimeType
 from .types import Chapter, PathLike, AudioInfo, AudioStats, AudioFrame
 from .files import ensure_path_exists
 from .log import error, warn, debug, info
@@ -12,7 +14,7 @@ from .download import get_executable
 from .convert import (
     timedelta_from_formatted,
     timedelta_to_frame,
-    frame_to_timedelta,
+    frame_to_ms,
     mpls_timestamp_to_timedelta,
     format_timedelta,
 )
@@ -213,7 +215,7 @@ def parse_chapters_bdmv(
 
                     for i, lmark in enumerate(linked_marks, start=1):
                         time = mpls_timestamp_to_timedelta(lmark.mark_timestamp - offset)
-                        if clip_frames > 0 and time > frame_to_timedelta(clip_frames - 50, fps):
+                        if clip_frames > 0 and time > timedelta(milliseconds=frame_to_ms(clip_frames - 50, TimeType.EXACT, fps, False)):
                             continue
                         chapters.append((time, f"Chapter {i:02.0f}"))
                     if chapters and _print:

--- a/muxtools/utils/parsing.py
+++ b/muxtools/utils/parsing.py
@@ -157,7 +157,7 @@ def parse_chapters_bdmv(
     Attempts to parse chapters from the bluray metadata
 
     :param src:         The m2ts file you're currently using
-    :param clip_fps:    The fps of the clip. Also accepts a timecode (v2) file.
+    :param clip_fps:    The fps of the clip. Also accepts a timecode (v2, v4) file.
     :param clip_frames: Total frames of the clip
     :param _print:      Prints the chapters after parsing if true
 

--- a/muxtools/utils/parsing.py
+++ b/muxtools/utils/parsing.py
@@ -13,7 +13,7 @@ from .log import error, warn, debug, info
 from .download import get_executable
 from .convert import (
     timedelta_from_formatted,
-    timedelta_to_frame,
+    ms_to_frame,
     frame_to_ms,
     mpls_timestamp_to_timedelta,
     format_timedelta,
@@ -220,7 +220,7 @@ def parse_chapters_bdmv(
                         chapters.append((time, f"Chapter {i:02.0f}"))
                     if chapters and _print:
                         for time, name in chapters:
-                            print(f"{name}: {format_timedelta(time)} | {timedelta_to_frame(time, fps)}")
+                            print(f"{name}: {format_timedelta(time)} | {ms_to_frame(int(time.total_seconds() * 1000), TimeType.EXACT, fps)}")
 
         if chapters:
             break

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pyparsebluray>=0.1.4",
     "pydantic>=2.5.0",
     "psutil>=5.6.4",
+    "videotimestamps>=0.1.0",
 ]
 classifiers = [
     "Natural Language :: English",


### PR DESCRIPTION
I replaced some functions in `convert.py` to use [VideoTimestamps](https://github.com/moi15moi/VideoTimestamps/). Now, the functions `ms_to_frame` and `frame_to_ms` are frame-perfect.

There are breaking changes:
- `frame_to_timedelta` has been replaced with `frame_to_ms`.
- `timedelta_to_frame` has been replaced with `ms_to_frame`.

This PR will require extensive testing.

---