### PR TITLE
fix: path not returned as str on windows

### DIFF
--- a/muxtools/utils/download.py
+++ b/muxtools/utils/download.py
@@ -66,7 +66,7 @@ def get_executable(type: str, can_download: bool | None = None, can_error: bool 
         else:
             path = download_binary(type)
 
-    return path
+    return str(path)
 
 
 def download_binary(type: str) -> str:


### PR DESCRIPTION
When `print_cli` is set to true on the main mux function, it can fail as `sh.which(...)` (in `utils/download.py:get_executable`) does not always return a string and can return a `WindowsPath` object, causing `joincommand(...)` (in `muxing/mux.py:mux`) to fail.

Before change:
![image](https://github.com/user-attachments/assets/e656ab19-b5e7-4a0d-b8c0-6165d04b424c)

After change:
No error (yipee)