### PR TITLE
clean_styles: improve regex

### DIFF
--- a/muxtools/subtitle/sub.py
+++ b/muxtools/subtitle/sub.py
@@ -131,7 +131,7 @@ class SubFile(BaseSubFile):
         """
         doc = self._read_doc()
         used_styles = {line.style for line in doc.events if line.TYPE == "Dialogue"}
-        regex = re.compile(r"\{.*?\\r([^\\]+)\}")
+        regex = re.compile(r"\{[^}]*\\r([^\\}]+)[^}]*\}")
         for line in [line for line in doc.events if line.TYPE == "Dialogue"]:
             for match in regex.finditer(line.text):
                 used_styles.add(match.group(1))


### PR DESCRIPTION
The current regex fails to match styles if they are followed by other tags.

Before:
```python
>>> re.findall(r"\{.*?\\r([^\\]+)\}", R"{\rDefault\i1} {\rAlt}{}")
['Alt}{']
```

After:
```python
>>> re.findall(r"\{[^}]*\\r([^\\}]+)[^}]*\}", R"{\rDefault\i1} {\rAlt}{}"
['Default', 'Alt']
```