### PR TITLE
autoswapper: allow tags in swapped text, and improve docs

### DIFF
--- a/muxtools/subtitle/sub.py
+++ b/muxtools/subtitle/sub.py
@@ -222,9 +222,9 @@ class SubFile(BaseSubFile):
 
         marker = re.escape(inline_marker)
 
-        ab_swap_regex = re.compile(rf"{{{marker}}}(.*){{{marker}([^}}*]+)}}")
+        ab_swap_regex = re.compile(rf"{{{marker}}}(.*?){{{marker}([^}}*]+)}}")
         show_word_regex = re.compile(rf"{{{marker}{marker}([^}}]+)}}")
-        hide_word_regex = re.compile(rf"{{{marker}}}(.*){{{marker} *}}")
+        hide_word_regex = re.compile(rf"{{{marker}}}(.*?){{{marker} *}}")
 
         def _do_autoswap(lines: LINES):
             for i, line in enumerate(lines):

--- a/muxtools/subtitle/sub.py
+++ b/muxtools/subtitle/sub.py
@@ -169,19 +169,43 @@ class SubFile(BaseSubFile):
         print_swaps: bool = False,
         inline_marker: str = "*",
         line_marker: str = "***",
+        inline_tag_markers: str | None = None,
     ) -> SubFileSelf:
-        """
-        autoswapper does the swapping.
-        Too lazy to explain
+        r"""
+        autoswapper allows replacing text in the script with a different text.
+        Useful for creating honorific tracks.
 
-        :param allowed_styles:      List of allowed styles to do the swapping on
-                                    Will run on every line if passed `None`
-        :param print_swaps:         Prints the swaps
-        :param inline_marker:       Marker to use for inline swaps.
-                                    Should be one character. Default `*`
-        :param line_marker:         Marker to use for full-line swaps. Default `***`
+        Assuming the markers are as default:
 
-        :return:                    This SubTrack
+        - `{*}abc{*def}` becomes `{*}def{*abc}` (AB Swap)
+        - `abc{**def}` becomes `abc{*}def{*}` (Show Word)
+        - `abc{*}def{*}` becomes `abc{**def}` (Hide Word)
+
+        Note: AB Swap and Hide Word will remove `{}` from the swapped text, to ensure the comment isn't broken.
+
+        You can also comment in or out entire lines by using the line marker in either the `effect` or `name` field.
+        - A dialogue line with effect or name set to `***` will be commented.
+        - A comment line with effect or name set to `***` will be set to a dialogue.
+
+
+        `inline_tag_markers` can be used to swap ASS tags as well.
+
+        Assuming the markers are as default, except inline_tag_markers = `[]`:
+        - `{*}{\i1}abc{*[\b1]def}` becomes `{*}{\b1}def{*[\i1]abc}` (AB Swap)
+        - `abc{**[\b1]def}` becomes `abc{*}{\b1}def{*}` (Show Word)
+        - `abc{*}{\b1}def{*}` becomes `abc{**[\b1]def}` (Hide Word)
+
+
+        :param allowed_styles:          List of allowed styles to do the swapping on
+                                        Will run on every line if passed `None`
+        :param print_swaps:             Prints the swaps
+        :param inline_marker:           Marker to use for inline swaps.
+                                        Should be one character. Default `*`
+        :param line_marker:             Marker to use for full-line swaps. Default `***`
+        :param inline_tag_markers:      Two characters that will be replaced with `{}` respectively in the inline swaps.
+                                        Defaults to `None`, which will just remove the `{}` from the swapped text.
+
+        :return:                        This SubTrack
         """
         if not isinstance(inline_marker, str) or not inline_marker.strip():
             warn("Given invalid inline marker. Using default '*'.", self)
@@ -191,11 +215,16 @@ class SubFile(BaseSubFile):
             warn("Given invalid line marker. Using default '***'.", self)
             line_marker = "***"
 
+        if inline_tag_markers:
+            if len(inline_tag_markers) != 2 or inline_tag_markers[0] == inline_tag_markers[1] or any([m in "{}" for m in inline_tag_markers]):
+                warn("Given invalid inline comment markers. Using default 'None'.", self)
+                inline_tag_markers = None
+
         marker = re.escape(inline_marker)
 
-        ab_swap_regex = re.compile(rf"{{{marker}}}([^{{]*){{{marker}([^}}*]+)}}")
+        ab_swap_regex = re.compile(rf"{{{marker}}}(.*){{{marker}([^}}*]+)}}")
         show_word_regex = re.compile(rf"{{{marker}{marker}([^}}]+)}}")
-        hide_word_regex = re.compile(rf"{{{marker}}}([^{{]*){{{marker} *}}")
+        hide_word_regex = re.compile(rf"{{{marker}}}(.*){{{marker} *}}")
 
         def _do_autoswap(lines: LINES):
             for i, line in enumerate(lines):
@@ -203,16 +232,41 @@ class SubFile(BaseSubFile):
                     to_swap: dict = {}
                     # {*}This will be replaced{*With this}
                     for match in re.finditer(ab_swap_regex, line.text):
-                        to_swap.update({f"{match.group(0)}": f"{{{inline_marker}}}{match.group(2)}{{{inline_marker}{match.group(1)}}}"})
+                        if inline_tag_markers:
+                            to_swap.update(
+                                {
+                                    f"{match.group(0)}": f"{{{inline_marker}}}{match.group(2).replace(inline_tag_markers[0], '{').replace(inline_tag_markers[1], '}')}{{{inline_marker}{match.group(1).replace('{', inline_tag_markers[0]).replace('}', inline_tag_markers[1])}}}"
+                                }
+                            )
+                        else:
+                            to_swap.update(
+                                {
+                                    f"{match.group(0)}": f"{{{inline_marker}}}{match.group(2)}{{{inline_marker}{match.group(1).replace('{', '').replace('}', '')}}}"
+                                }
+                            )
 
                     # This sentence is no longer{** incomplete}
                     for match in re.finditer(show_word_regex, line.text):
-                        to_swap.update({f"{match.group(0)}": f"{{{inline_marker}}}{match.group(1)}{{{inline_marker}}}"})
+                        if inline_tag_markers:
+                            to_swap.update(
+                                {
+                                    f"{match.group(0)}": f"{{{inline_marker}}}{match.group(1).replace(inline_tag_markers[0], '{').replace(inline_tag_markers[1], '}')}{{{inline_marker}}}"
+                                }
+                            )
+                        else:
+                            to_swap.update({f"{match.group(0)}": f"{{{inline_marker}}}{match.group(1)}{{{inline_marker}}}"})
 
-                    # This sentence is no longer{*} incomplete{*}
+                    # This sentence is no longer{*} complete{*}
                     for match in re.finditer(hide_word_regex, line.text):
-                        to_swap.update({f"{match.group(0)}": f"{{{inline_marker*2}{match.group(1)}}}"})
-                    # print(to_swap)
+                        if inline_tag_markers:
+                            to_swap.update(
+                                {
+                                    f"{match.group(0)}": f"{{{inline_marker*2}{match.group(1).replace('{', inline_tag_markers[0]).replace('}', inline_tag_markers[1])}}}"
+                                }
+                            )
+                        else:
+                            to_swap.update({f"{match.group(0)}": f"{{{inline_marker*2}{match.group(1).replace('{', '').replace('}', '')}}}"})
+
                     for key, val in to_swap.items():
                         if print_swaps:
                             info(f'autoswapper: Swapped "{key}" for "{val}" on line {i}', self)


### PR DESCRIPTION
This PR allows tags to exist in swapped text, whilst also allowing for different markers to be used to swap different things (for example, honorifics and dub voiceover for forced subs). It also improves the docs for autoswapper. None of these are breaking changes.

### Regex changes:
(This was changed very slightly to make the quanitfier lazy, to allow multiple swaps in a single line. See 2nd commit.)

`ab_swap_regex`: allows matches with all characters between the markers.
- Before: 
![image](https://github.com/user-attachments/assets/c07c5f56-18f3-4070-ab7c-d7e871ae457b)
- After:
![image](https://github.com/user-attachments/assets/c772fa8c-47b3-42d9-83e7-3b3ae0f3533c)

`hide_word_regex`: again, allows matches with all characters between the markers.
- Before:
![image](https://github.com/user-attachments/assets/5377ff8d-8c1b-4a3a-a8d8-149266e70537)
- After:
![image](https://github.com/user-attachments/assets/ffa01ed7-8725-405e-b3a8-22e0b11173de)

### Other changes:
- Added `inline_tag_markers` argument to autoswapper.
  - This allows tags to exist inside of tags, by replacing `{}` with other characters, such as `[]`.
  - Defaults to None, so this behaviour is not by default. If it defaults to `[]`, then it could create issues if someone is using those characters in swapped strings.
- Removes/replaces `{}` from inside of tags when swapping.
  - Having a `}` inside of a tag would cause it to end early, so this is a fix to unexpected behavior.
  - Removes when `inline_tag_markers` is None, replaces if not.

### Example of usage:
```py
from muxtools import SubFile, Setup

setup = Setup(
    config_file=None, # type: ignore
    work_dir="build",
)

forced = SubFile(['ts.ass']).autoswapper(
    allowed_styles=None,
    inline_marker="*",
    line_marker="***",
    print_swaps=True,
    inline_tag_markers='[]'
)
honorific = SubFile(['ts.ass']).autoswapper(
    allowed_styles=None,
    inline_marker="^",
    line_marker="^^^",
    print_swaps=True,
    inline_tag_markers='[]'
)
```
`ts.ass` events: (input)
```
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{*}Komi tried to make a joke.{*Her attempt at a joke.}
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{*}Komi{^^-san} tried to make a joke.{*Her attempt at a joke.}
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{*}Komi tried to make a {\i1}joke.{\i0}{*Her attempt at a joke.}
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,Komi got a {*}yaku {*}combo.
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,Komi got a {*}{\i1}yaku{\i0}{*}combo.
```
`ts_vof.ass` events: (output of forced, swap char is `*`)
```
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{*}Her attempt at a joke.{*Komi tried to make a joke.}
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{*}Her attempt at a joke.{*Komi[^^-san] tried to make a joke.}
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{*}Her attempt at a joke.{*Komi tried to make a [\i1]joke.[\i0]}
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,Komi got a {**yaku }combo.
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,Komi got a {**[\i1]yaku[\i0]}combo.
```
`ts_vof (1).ass` events: (output of honorific, swap char is `^`)
```
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{*}Komi tried to make a joke.{*Her attempt at a joke.}
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{*}Komi{^}-san{^} tried to make a joke.{*Her attempt at a joke.}
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{*}Komi tried to make a {\i1}joke.{\i0}{*Her attempt at a joke.}
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,Komi got a {*}yaku {*}combo.
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,Komi got a {*}{\i1}yaku{\i0}{*}combo.
```