### PR TITLE
do_audio: fix audio processing when there's no extractor

### DIFF
--- a/muxtools/functions.py
+++ b/muxtools/functions.py
@@ -21,7 +21,7 @@ def do_audio(
     trims: Trim | list[Trim] | None = None,
     fps: Fraction | PathLike | Sequence[int] = Fraction(24000, 1001),
     num_frames: int = 0,
-    extractor: Extractor = FFMpeg.Extractor(),
+    extractor: Extractor | None = FFMpeg.Extractor(),
     trimmer: Trimmer | None = AutoTrimmer(),
     encoder: Encoder | None = AutoEncoder(),
     quiet: bool = True,
@@ -77,6 +77,8 @@ def do_audio(
             audio = FFMpeg.Concat(extracted).concat_audio()
         else:
             audio = extractor.extract_audio(fileIn, quiet)
+    else:
+        audio = ensure_path_exists(fileIn, do_audio)
 
     if not isinstance(audio, AudioFile):
         audio = AudioFile.from_file(audio, do_audio)


### PR DESCRIPTION
In `vsmuxtools.do_audio()`, when passing an AudioNode the extractor is set to `None`. <https://github.com/Jaded-Encoding-Thaumaturgy/vs-muxtools/blob/v0.2.0/vsmuxtools/extension/audio.py#L93-L95>

This worked fine in muxtools v0.1.0 but then v0.2.0 changed how this `audio` variable was set, with it now only being set if an extractor was defined. So in the AudioNode case the variable is unbound and then:

    Traceback (most recent call last):
      File "test.py", line 5, in <module>
        do_audio(node)
      File ".venv/Lib/site-packages/vsmuxtools/extension/audio.py", line 105, in do_audio
        return mt_audio(fileIn, track, trims, fps, num_frames, extractor, trimmer, encoder, quiet, output)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "muxtools/functions.py", line 83, in do_audio
        if not isinstance(audio, AudioFile):
                          ^^^^^
    UnboundLocalError: cannot access local variable 'audio' where it is not associated with a value

Minimal repro:

```python
from vsmuxtools import do_audio
from vstools import core

node = core.std.BlankAudio()
do_audio(node)
```

What v0.1.0 was doing was a `audio = ensure_path_exists(fileIn, do_audio)`, so this patch brings that back for the no-extractor case.

I didn't add a check for `list[PathLike]` because the "list of files must use FFMpeg extractor" check should protect this from that possibility.