### PR TITLE
autoswapper: allow * in swap string

### DIFF
--- a/muxtools/subtitle/sub.py
+++ b/muxtools/subtitle/sub.py
@@ -222,7 +222,7 @@ class SubFile(BaseSubFile):
 
         marker = re.escape(inline_marker)
 
-        ab_swap_regex = re.compile(rf"{{{marker}}}(.*?){{{marker}([^}}*]+)}}")
+        ab_swap_regex = re.compile(rf"{{{marker}}}(.*?){{{marker}([^}}]+)}}")
         show_word_regex = re.compile(rf"{{{marker}{marker}([^}}]+)}}")
         hide_word_regex = re.compile(rf"{{{marker}}}(.*?){{{marker} *}}")
 


### PR DESCRIPTION
Not sure why * aren't allowed in ab swaps, but it conflicts with character to character gradient generated ass tags.