### PR TITLE
build-backend: switch from setuptools to hatchling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,31 +9,18 @@ jobs:
     name: Build and push to PyPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Prep Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: Install build tools
-        run: |
-          python -m pip install build setuptools twine wheel --user
-        continue-on-error: false
-      - name: Build source and wheel
-        id: build
-        run: |
-          python -m build --outdir dist/
-        continue-on-error: true
-      - name: Check the output
-        run: |
-          python -m twine check --strict dist/*
-        continue-on-error: false
-      - name: Die on failure
-        if: steps.build.outcome != 'success'
-        run: exit 1
+      - name: Build
+        run: pipx run build
+
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.AUTH_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,11 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 readme = "README.md"
-license = { text = "MPL 2.0" }
+license = "MPL-2.0"
 
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project.urls]
 "Source Code" = "https://github.com/Vodes/muxtools"


### PR DESCRIPTION
Switching build-backend from setuptools to [hatchling](https://pypi.org/project/hatchling/) as discussed on Snackbox.

I've picked hatchling because it's the [default PyPA recommendation](https://packaging.python.org/en/latest/tutorials/packaging-projects/), supports the latest [core metadata 2.4](https://packaging.python.org/en/latest/specifications/core-metadata/#history) and I've used it myself without any issues.

Don't think it matters too much but it also builds faster now.