### PR TITLE
Fix Path object not converted to str when adding to args list

### DIFF
--- a/muxtools/muxing/mux.py
+++ b/muxtools/muxing/mux.py
@@ -72,7 +72,7 @@ def mux(*tracks, tmdb: TmdbConfig | None = None, outfile: PathLike | None = None
             # Failsave for if someone passes Chapters().to_file() or a txt/xml file
             track = ensure_path_exists(track, "Mux")
             if track.suffix.lower() in [".txt", ".xml"]:
-                args.extend(["--chapters", track.resolve()])
+                args.extend(["--chapters", str(track.resolve())])
                 continue
         elif track is None:
             continue


### PR DESCRIPTION
When setting `print_cli=True` and passing a PathLike object this error will be raised:
```
Traceback (most recent call last):
  File "script.py", line 251, in <module>
    mmux(
    ~~~~^
        video.to_track('JPBD encode', 'jpn'),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        quiet=False, print_cli=True
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "venv\Lib\site-packages\muxtools\muxing\mux.py", line 86, in mux
    info(joincommand(args), "Mux")
         ~~~~~~~~~~~^^^^^^
  File "C:\Users\Varde\AppData\Local\Programs\Python\Python313\Lib\shlex.py", line 318, in join
    return ' '.join(quote(arg) for arg in split_command)
           ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Varde\AppData\Local\Programs\Python\Python313\Lib\shlex.py", line 318, in <genexpr>
    return ' '.join(quote(arg) for arg in split_command)
                    ~~~~~^^^^^
  File "C:\Users\Varde\AppData\Local\Programs\Python\Python313\Lib\shlex.py", line 327, in quote
    if _find_unsafe(s) is None:
       ~~~~~~~~~~~~^^^
TypeError: expected string or bytes-like object, got 'WindowsPath'
```

Repro code:
```py
muxtools.muxing.mux.mux(
        video.to_track('JPBD encode', 'jpn'),
        audio.to_track('FLAC 2.0', 'jpn'),
        chaps.to_file(minus_one_ms_hack=False),
        quiet=False, print_cli=True
)
```
