### PR TITLE
fix: Enable chapter parsing in `ParsedFile.from_file()`

### DIFF
--- a/muxtools/utils/probe.py
+++ b/muxtools/utils/probe.py
@@ -102,7 +102,7 @@ class ParsedFile:
         path = ensure_path_exists(path, caller)
         ffprobe_exe = get_executable("ffprobe")
         try:
-            out = probe_obj(path, cmd=ffprobe_exe)
+            out = probe_obj(path, cmd=ffprobe_exe, show_chapters=True)
             assert out and out.format
         except:
             raise error(f"Failed to parse file '{path.stem}' with ffprobe!", caller)


### PR DESCRIPTION
By default typed_ffmpeg's ``probe_obj()`` doesn't return available chapters. This fixes that so now ``ParsedFile.raw_ffprobe.chapters`` isn't always ``None``. 