### PR TITLE
Implement mkvpropedit and bitstream filter helpers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
           sudo ln -sf "$PWD/squashfs-root/usr/bin/mkvmerge" "/usr/bin/mkvmerge"
           sudo ln -sf "$PWD/squashfs-root/usr/bin/mkvpropedit" "/usr/bin/mkvpropedit"
           sudo ln -sf "$PWD/squashfs-root/usr/bin/mkvinfo" "/usr/bin/mkvinfo"
+          sudo ln -sf "$PWD/squashfs-root/usr/bin/mkvextract" "/usr/bin/mkvextract"
       - name: Check mkvmerge
         run: mkvmerge --version
       - name: Run tests (Python ${{ matrix.python-version }})

--- a/muxtools/__init__.py
+++ b/muxtools/__init__.py
@@ -3,6 +3,7 @@ from .muxing import *
 from .audio import *
 from .subtitle import *
 from .misc import *
+from .helpers import *
 
 from . import main
 from . import functions

--- a/muxtools/helpers/__init__.py
+++ b/muxtools/helpers/__init__.py
@@ -1,3 +1,3 @@
 from . import propedit
 
-from propedit import *
+from .propedit import *

--- a/muxtools/helpers/__init__.py
+++ b/muxtools/helpers/__init__.py
@@ -1,3 +1,4 @@
 from . import propedit
 
 from .propedit import *
+from .bsf import *

--- a/muxtools/helpers/__init__.py
+++ b/muxtools/helpers/__init__.py
@@ -1,0 +1,3 @@
+from . import propedit
+
+from propedit import *

--- a/muxtools/helpers/bsf/__init__.py
+++ b/muxtools/helpers/bsf/__init__.py
@@ -1,4 +1,5 @@
-from . import generic_enums, bsf_mpeg2
+from . import bsf_generic, bsf_mpeg2, bsf_hevc_avc
 
-from .generic_enums import *
+from .bsf_generic import *
 from .bsf_mpeg2 import *
+from .bsf_hevc_avc import *

--- a/muxtools/helpers/bsf/__init__.py
+++ b/muxtools/helpers/bsf/__init__.py
@@ -1,0 +1,4 @@
+from . import generic_enums, bsf_mpeg2
+
+from .generic_enums import *
+from .bsf_mpeg2 import *

--- a/muxtools/helpers/bsf/bsf_hevc_avc.py
+++ b/muxtools/helpers/bsf/bsf_hevc_avc.py
@@ -1,0 +1,161 @@
+from typing import Any
+
+from ...utils import ensure_path_exists, PathLike, error
+from .bsf_generic import BSF_Matrix, BSF_Primaries, BSF_Transfer, BSF_Format, BSF_ChromaLocation, _apply_bsf
+
+__all__ = ["apply_avc_bsf", "apply_hevc_bsf"]
+
+
+def _resolve_crop(crop: int | tuple[int, int] | tuple[int, int, int, int]) -> list[str]:
+    if isinstance(crop, int):
+        crop = tuple([crop] * 4)
+    elif len(crop) == 2:
+        crop = crop * 2
+    return [f"crop_left={str(crop[0])}", f"crop_top={str(crop[1])}", f"crop_right={str(crop[2])}", f"crop_bottom={str(crop[3])}"]
+
+
+def _apply_avc_hevc_bsf(
+    fileIn: PathLike,
+    filter_name: str,
+    sar: int | None = None,
+    cloc_type: BSF_ChromaLocation | int | None = None,
+    full_range: bool | int | None = None,
+    format: BSF_Format | int | None = None,
+    primaries: BSF_Primaries | int | None = None,
+    transfer: BSF_Transfer | int | None = None,
+    matrix: BSF_Matrix | int | None = None,
+    crop: int | tuple[int, int] | tuple[int, int, int, int] | None = None,
+    quiet: bool = True,
+    caller: Any = None,
+    **kwargs: bool | str,
+):
+    f = ensure_path_exists(fileIn, caller)
+    filter_options = list[str]()
+
+    if sar is not None:
+        filter_options.append(f"sample_aspect_ratio={str(sar)}")
+    if full_range is not None:
+        filter_options.append(f"video_full_range_flag={str(int(full_range))}")
+
+    if cloc_type is not None and (cloc_type := BSF_ChromaLocation(cloc_type)) is not None:
+        filter_options.append(f"chroma_sample_loc_type={str(cloc_type.value)}")
+    if format is not None and (format := BSF_Format(format)) is not None:
+        filter_options.append(f"video_format={str(format.value)}")
+    if primaries is not None and (primaries := BSF_Primaries(primaries)) is not None:
+        filter_options.append(f"colour_primaries={str(primaries.value)}")
+    if transfer is not None and (transfer := BSF_Transfer(transfer)) is not None:
+        filter_options.append(f"transfer_characteristics={str(transfer.value)}")
+    if matrix is not None and (matrix := BSF_Matrix(matrix)) is not None:
+        filter_options.append(f"matrix_coefficients={str(matrix.value)}")
+    if crop is not None:
+        filter_options.extend(_resolve_crop(crop))
+
+    if kwargs:
+        for key, value in kwargs.items():
+            if isinstance(value, bool):
+                filter_options.append(f"{key}={str(int(value))}")
+            else:
+                filter_options.append(f"{key}={str(value)}")
+
+    if not filter_options:
+        raise error("No changes to be made!", caller)
+
+    _apply_bsf(f, filter_name, filter_options, caller, quiet)
+
+
+def apply_avc_bsf(
+    fileIn: PathLike,
+    sar: int | None = None,
+    cloc_type: BSF_ChromaLocation | int | None = None,
+    full_range: bool | int | None = None,
+    format: BSF_Format | int | None = None,
+    primaries: BSF_Primaries | int | None = None,
+    transfer: BSF_Transfer | int | None = None,
+    matrix: BSF_Matrix | int | None = None,
+    crop: int | tuple[int, int] | tuple[int, int, int, int] | None = None,
+    quiet: bool = True,
+    **kwargs: bool | str,
+):
+    """
+    A helper for the FFMpeg [h264_metadata](https://ffmpeg.org/ffmpeg-bitstream-filters.html#h264_005fmetadata) bitstream filter.
+
+    `None` values will do nothing to the respective metadata flags.
+
+    :param fileIn:                      The file to modify
+    :param sar:                         Set the sample aspect ratio in the stream
+    :param cloc_type:                   Set the chroma sample location in the stream
+    :param full_range:                  Set the full range flag in the stream
+    :param format:                      Set the video format in the stream
+    :param primaries:                   Set the color primaries in the stream
+    :param transfer:                    Set the transfer characteristics in the stream
+    :param matrix:                      Set the matrix coefficients in the stream
+    :param crop:                        Set the crop values in the stream
+    :param quiet:                       Suppresses the output of ffmpeg
+    :param kwargs:                      Additional options for the filter.\n
+                                        For other available options, check the hyperlink to the filter above.
+    """
+
+    _apply_avc_hevc_bsf(
+        fileIn,
+        "h264_metadata",
+        sar=sar,
+        cloc_type=cloc_type,
+        full_range=full_range,
+        format=format,
+        primaries=primaries,
+        transfer=transfer,
+        matrix=matrix,
+        crop=crop,
+        quiet=quiet,
+        caller=apply_avc_bsf,
+        **kwargs,
+    )
+
+
+def apply_hevc_bsf(
+    fileIn: PathLike,
+    sar: int | None = None,
+    cloc_type: BSF_ChromaLocation | int | None = None,
+    full_range: bool | int | None = None,
+    format: BSF_Format | int | None = None,
+    primaries: BSF_Primaries | int | None = None,
+    transfer: BSF_Transfer | int | None = None,
+    matrix: BSF_Matrix | int | None = None,
+    crop: int | tuple[int, int] | tuple[int, int, int, int] | None = None,
+    quiet: bool = True,
+    **kwargs: bool | str,
+):
+    """
+    A helper for the FFMpeg [hevc_metadata](https://ffmpeg.org/ffmpeg-bitstream-filters.html#hevc_005fmetadata) bitstream filter.
+
+    `None` values will do nothing to the respective metadata flags.
+
+    :param fileIn:                      The file to modify
+    :param sar:                         Set the sample aspect ratio in the stream
+    :param cloc_type:                   Set the chroma sample location in the stream
+    :param full_range:                  Set the full range flag in the stream
+    :param format:                      Set the video format in the stream
+    :param primaries:                   Set the color primaries in the stream
+    :param transfer:                    Set the transfer characteristics in the stream
+    :param matrix:                      Set the matrix coefficients in the stream
+    :param crop:                        Set the crop values in the stream
+    :param quiet:                       Suppresses the output of ffmpeg
+    :param kwargs:                      Additional options for the filter.\n
+                                        For available options, check the hyperlink to the filter above.
+    """
+
+    _apply_avc_hevc_bsf(
+        fileIn,
+        "hevc_metadata",
+        sar=sar,
+        cloc_type=cloc_type,
+        full_range=full_range,
+        format=format,
+        primaries=primaries,
+        transfer=transfer,
+        matrix=matrix,
+        crop=crop,
+        quiet=quiet,
+        caller=apply_hevc_bsf,
+        **kwargs,
+    )

--- a/muxtools/helpers/bsf/bsf_mpeg2.py
+++ b/muxtools/helpers/bsf/bsf_mpeg2.py
@@ -1,0 +1,97 @@
+from enum import Enum
+from shutil import move
+
+from ...utils import ensure_path_exists, PathLike, error, get_executable, run_commandline, make_output, clean_temp_files
+from .generic_enums import BSF_Matrix, BSF_Primaries, BSF_Transfer, BSF_Format
+
+__all__ = [
+    "MPEG2_DAR",
+    "MPEG2_FPS",
+    "apply_mpeg2_bsf",
+]
+
+
+class MPEG2_DAR(Enum):
+    DAR_4_3 = "4/3"
+    DAR_16_9 = "16/9"
+    DAR_221_100 = "221/100"
+
+
+class MPEG2_FPS(Enum):
+    FPS_23_976 = "24000/1001"
+    FPS_24 = "24"
+    FPS_25 = "25"
+    FPS_29_97 = "30000/1001"
+    FPS_30 = "30"
+    FPS_50 = "50"
+    FPS_59_94 = "60000/1001"
+    FPS_60 = "60"
+
+
+def apply_mpeg2_bsf(
+    fileIn: PathLike,
+    dar: MPEG2_DAR | str | None = None,
+    fps: MPEG2_FPS | str | None = None,
+    format: BSF_Format | int | None = None,
+    primaries: BSF_Primaries | int | None = None,
+    transfer: BSF_Transfer | int | None = None,
+    matrix: BSF_Matrix | int | None = None,
+    quiet: bool = True,
+):
+    """
+    A helper for the FFMpeg [mpeg2_metadata](https://ffmpeg.org/ffmpeg-bitstream-filters.html#mpeg2_005fmetadata) bitstream filter.
+
+    `None` values will do nothing to the respective metadata flags.
+
+    :param fileIn:                      The file to modify
+    :param dar:                         Set the display aspect ratio in the stream
+    :param fps:                         Set the frame rate in the stream
+    :param format:                      Set the video format in the stream
+    :param primaries:                   Set the color primaries in the stream
+    :param transfer_characteristics:    Set the transfer characteristics in the stream
+    :param matrix_coefficients:         Set the matrix coefficients in the stream
+    :param quiet:                       Suppresses the output of ffmpeg
+    """
+    f = ensure_path_exists(fileIn, apply_mpeg2_bsf)
+    out = make_output(f, f.suffix[1:], "bsf", temp=True)
+    ffmpeg = get_executable("ffmpeg")
+    filter_options = list[str]()
+
+    if dar is not None:
+        filter_options.append(f"display_aspect_ratio={str(dar.value) if isinstance(dar, MPEG2_DAR) else str(dar)}")
+
+    if fps is not None:
+        filter_options.append(f"frame_rate={str(fps.value) if isinstance(fps, MPEG2_FPS) else str(fps)}")
+
+    if format is not None and (format := BSF_Format(format)):
+        filter_options.append(f"video_format={str(format.value)}")
+
+    if primaries is not None and (primaries := BSF_Primaries(primaries)):
+        if primaries.value not in range(1, 8):
+            raise error(f"'{primaries}' is not a valid primaries value for MPEG2 streams!")
+        filter_options.append(f"colour_primaries={str(primaries.value)}")
+
+    if transfer is not None and (transfer := BSF_Transfer(transfer)):
+        if transfer.value not in range(1, 9):
+            raise error(f"'{transfer}' is not a valid transfer value for MPEG2 streams!")
+        filter_options.append(f"transfer_characteristics={str(transfer.value)}")
+
+    if matrix is not None and (matrix := BSF_Matrix(matrix)):
+        if matrix.value not in range(1, 8):
+            raise error(f"'{matrix}' is not a valid matrix value for MPEG2 streams!")
+        filter_options.append(f"matrix_coefficients={str(matrix.value)}")
+
+    if not filter_options:
+        raise error("No changes to be made!", apply_mpeg2_bsf)
+
+    filter_options = ":".join(filter_options)
+    args = [ffmpeg, "-hide_banner", "-i", str(f), "-map", "0", "-c", "copy", "-bsf:v", f"mpeg2_metadata={filter_options}", str(out)]
+
+    result = run_commandline(args, quiet)
+    if bool(result):
+        clean_temp_files()
+        raise error("Failed to apply mpeg2 bitstream filter!", apply_mpeg2_bsf)
+
+    f.unlink()
+    move(out, f)
+    clean_temp_files()

--- a/muxtools/helpers/bsf/generic_enums.py
+++ b/muxtools/helpers/bsf/generic_enums.py
@@ -1,0 +1,100 @@
+from enum import IntEnum
+
+__all__ = ["BSF_Matrix", "BSF_Transfer", "BSF_Primaries", "BSF_Format"]
+
+
+class BSF_Matrix(IntEnum):
+    """
+    Collection of known bitstream matrix values.
+
+    For more documentation on these, check out the [H265 Specification](https://www.itu.int/rec/t-rec-h.265) (Table E.5) or [JET Documentation](https://jaded-encoding-thaumaturgy.github.io/vs-jetpack/api/vstools/enums/color/#vstools.enums.color.Matrix).
+    """
+
+    RGB = 0
+    GBR = RGB
+    IDENTITY = RGB
+    BT709 = 1
+    UNKNOWN = 2
+    FCC = 3
+    BT470BG = 5
+    BT601_625 = BT470BG
+    SMPTE170M = 6
+    BT601_525 = SMPTE170M
+    SMPTE240M = 7
+    YCGCO = 8
+    BT2020NCL = 9
+    BT2020CL = 10
+    CHROMANCL = 12
+    CHROMACL = 13
+    ICTCP = 14
+
+
+class BSF_Transfer(IntEnum):
+    """
+    Collection of known bitstream transfer values.
+
+    For more documentation on these, check out the [H265 Specification](https://www.itu.int/rec/t-rec-h.265) (Table E.4) or [JET Documentation](https://jaded-encoding-thaumaturgy.github.io/vs-jetpack/api/vstools/enums/color/#vstools.enums.color.Transfer).
+    """
+
+    BT709 = 1
+    BT1886 = BT709
+    UNKNOWN = 2
+    BT470M = 4
+    BT470BG = 5
+    SMPTE170M = 6
+    BT601 = SMPTE170M
+    SMPTE240M = 7
+    LINEAR = 8
+    LOG100 = 9
+    LOG316 = 10
+    XVYCC = 11
+    SRGB = 13
+    BT2020_10 = 14
+    BT2020_12 = 15
+    ST2084 = 16
+    PQ = ST2084
+    STD_B67 = 18
+    HLG = STD_B67
+
+
+class BSF_Primaries(IntEnum):
+    """
+    Collection of known bitstream color primaries values.
+
+    For more documentation on these, check out the [H265 Specification](https://www.itu.int/rec/t-rec-h.265) (Table E.3) or [JET Documentation](https://jaded-encoding-thaumaturgy.github.io/vs-jetpack/api/vstools/enums/color/#vstools.enums.color.Primaries).
+    """
+
+    BT709 = 1
+    UNKNOWN = 2
+    BT470M = 4
+    BT470BG = 5
+    BT601_625 = BT470BG
+    SMPTE170M = 6
+    BT601_525 = SMPTE170M
+    SMPTE240M = 7
+    FILM = 8
+    BT2020 = 9
+    ST428 = 10
+    XYZ = ST428
+    CIE1931 = ST428
+    ST431_2 = 11
+    DCI_P3 = ST431_2
+    ST432_1 = 12
+    DISPLAY_P3 = ST432_1
+    JEDEC_P22 = 22
+    EBU3213 = JEDEC_P22
+
+
+class BSF_Format(IntEnum):
+    """
+    Collection of known bitstream video_format values.
+
+    For more documentation on these, check out the [H265 Specification](https://www.itu.int/rec/t-rec-h.265) (Table E.2)
+    """
+
+    COMPONENT = 0
+    PAL = 1
+    NTSC = 2
+    SECAM = 3
+    MAC = 4
+    UNSPECIFIED = 5

--- a/muxtools/helpers/propedit.py
+++ b/muxtools/helpers/propedit.py
@@ -1,0 +1,247 @@
+from pathlib import Path
+from typing_extensions import Self
+
+from ..misc import Chapters
+from ..utils import PathLike, ensure_path_exists, make_output, ensure_path, get_executable, run_commandline
+from ..utils.files import create_tags_xml
+from ..utils.log import error
+
+__all__ = ["MKVPropEdit"]
+
+
+class MKVPropEdit:
+    main_args: list[str]
+    track_args: list[str]
+    fileIn: Path
+    has_info: bool = False
+    video_index: int = 1
+    audio_index: int = 1
+    subtitle_index: int = 1
+    executable: Path
+
+    def __init__(
+        self, fileIn: PathLike, track_statistics: bool | None = None, chapters: PathLike | Chapters = None, tags: dict[str, str] | None = None
+    ):
+        """
+        Creates the mkvpropedit helper including any modifications possible on the global scope.
+
+        :param fileIn:              File to edit.
+        :param track_statistics:    Whether to update or remove track statistics like bitrate.\n
+                                    `None` will do nothing while `True` will add/replace them and `False` will remove them.
+
+        :param chapters:            Chapters to add to the file. This can be any txt or xml file in the same formats that mkvmerge takes.\n
+                                    It can also take a muxtools Chapters object and create a txt from that.\n
+                                    An empty string will remove any chapters. `None` will do nothing.
+
+        :param tags:                Global tags to add or replace.\n
+                                    An empty dict will remove any global tags. `None` will do nothing.
+        """
+        self.executable = ensure_path(get_executable("mkvpropedit"), self)
+        self.fileIn = ensure_path_exists(fileIn, self)
+        self.main_args = []
+        self.track_args = []
+
+        if track_statistics is not None:
+            self.main_args.append("--add-track-statistics-tags" if track_statistics else "--delete-track-statistics-tags")
+
+        if chapters is not None:
+            if isinstance(chapters, str) and not chapters:
+                self.main_args.extend(["-c", ""])
+            else:
+                if isinstance(chapters, Chapters):
+                    chapters = chapters.to_file()
+                chapters = ensure_path_exists(chapters, self)
+                if chapters.suffix.lower() not in [".txt", ".xml"]:
+                    raise error("Chapters have to be a txt or xml file.", self)
+                self.main_args.extend(["-c", str(chapters)])
+        if tags is not None:
+            out = ""
+            if len(tags) > 0:
+                out = make_output(fileIn, "xml", "global_tags", temp=True)
+                create_tags_xml(out, tags)
+            self.main_args.extend(["-t", f"global:{str(out)}"])
+
+    def _edit_args(self, name: str, value: bool | str | None) -> list[str]:
+        if value is None:
+            return []
+
+        if isinstance(value, bool):
+            return ["-s", f"{name}={str(int(value))}"]
+        else:
+            if not value:
+                return ["-d", name]
+            else:
+                return ["-s", f"{name}={value}"]
+
+    def _edit_track(
+        self,
+        type: str,
+        index: int,
+        title: str | None,
+        language: str | None,
+        default: bool | None,
+        forced: bool | None,
+        tags: dict[str, str] | None,
+        **kwargs: bool | str | None,
+    ):
+        selector = type if index <= 0 else f"{type}{index}"
+        if tags is not None:
+            out = ""
+            if len(tags) > 0:
+                out = make_output(self.fileIn, "xml", f"{selector}_tags", temp=True)
+                create_tags_xml(out, tags)
+            self.main_args.extend(["-t", f"{selector}:{str(out)}"])
+        if not any([not_none for not_none in (title, language, default, forced) if not_none is not None]) and not kwargs:
+            return
+
+        args = ["-e", selector]
+        to_append = [
+            *self._edit_args("title" if type == "info" else "name", title),
+            *self._edit_args("language", language),
+            *self._edit_args("flag-default", default),
+            *self._edit_args("flag-forced", forced),
+        ]
+        args.extend(to_append)
+
+        for k, v in kwargs.items():
+            if not k.endswith("_"):
+                k = k[:-1].replace("_", "-")
+            if e_args := self._edit_args(k, v):
+                args.extend(e_args)
+
+        self.track_args.extend(args)
+
+    def info(
+        self,
+        title: str | None = None,
+        date: str | None = None,
+        muxing_application: str | None = None,
+        writing_application: str | None = None,
+        **kwargs: bool | str | None,
+    ):
+        """
+        Edit properties for the main info section.
+
+        `None` always means the property will be left untouched while an empty string will remove the property outright.\n
+        Bool values are converted to their respective integer to be passed on to mkvpropedit.
+
+        :param title:               The title for the whole movie
+        :param date:                The date the file was created
+        :param muxing_application:  The name of the application or library used for multiplexing the file
+        :param writing_application: The name of the application or library used for writing the file
+        :param kwargs:              Any other properties to set or remove.\n
+                                    Check out the 'Segment information' section in `mkvpropedit -l` to see what's available.
+        """
+        if self.has_info:
+            raise error("Info tagging was already added!", self)
+        self._edit_track("info", -1, title, date=date, muxing_application=muxing_application, writing_application=writing_application, **kwargs)
+        self.has_info = True
+        return self
+
+    def video_track(
+        self,
+        name: str | None = None,
+        language: str | None = None,
+        default: bool | None = None,
+        forced: bool | None = None,
+        tags: dict[str, str] | None = None,
+        **kwargs: bool | str | None,
+    ) -> Self:
+        """
+        Edit properties for the next video track in the file.
+
+        `None` always means the property will be left untouched while an empty string will remove the property outright.\n
+        Bool values are converted to their respective integer to be passed on to mkvpropedit.
+
+        :param name:                A human-readable track name
+        :param language:            Specifies the language of the track
+        :param default:             Specifies whether a track should be eligible for automatic selection
+        :param forced:              Specifies whether a track should be played with tracks of a different type but same language
+
+        :param tags:                Any custom/arbitrary tags to set for the track.\n
+                                    An empty dict will remove any custom tags. `None` will do nothing.
+
+        :param kwargs:              Any other properties to set or remove.\n
+                                    Check out the 'Track headers' section in `mkvpropedit -l` to see what's available.
+        """
+        self._edit_track("v", self.video_index, name, language, default, forced, tags, **kwargs)
+        self.video_index += 1
+        return self
+
+    def audio_track(
+        self,
+        name: str | None = None,
+        language: str | None = None,
+        default: bool | None = None,
+        forced: bool | None = None,
+        tags: dict[str, str] | None = None,
+        **kwargs: bool | str | None,
+    ) -> Self:
+        """
+        Edit properties for the next audio track in the file.
+
+        `None` always means the property will be left untouched while an empty string will remove the property outright.\n
+        Bool values are converted to their respective integer to be passed on to mkvpropedit.
+
+        :param name:                A human-readable track name
+        :param language:            Specifies the language of the track
+        :param default:             Specifies whether a track should be eligible for automatic selection
+        :param forced:              Specifies whether a track should be played with tracks of a different type but same language
+
+        :param tags:                Any custom/arbitrary tags to set for the track.\n
+                                    An empty dict will remove any custom tags. `None` will do nothing.
+
+        :param kwargs:              Any other properties to set or remove.\n
+                                    Check out the 'Track headers' section in `mkvpropedit -l` to see what's available.
+        """
+        self._edit_track("a", self.audio_index, name, language, default, forced, tags, **kwargs)
+        self.audio_index += 1
+        return self
+
+    def sub_track(
+        self,
+        name: str | None = None,
+        language: str | None = None,
+        default: bool | None = None,
+        forced: bool | None = None,
+        tags: dict[str, str] | None = None,
+        **kwargs: bool | str | None,
+    ) -> Self:
+        """
+        Edit properties for the next subtitle track in the file.
+
+        `None` always means the property will be left untouched while an empty string will remove the property outright.\n
+        Bool values are converted to their respective integer to be passed on to mkvpropedit.
+
+        :param name:                A human-readable track name
+        :param language:            Specifies the language of the track
+        :param default:             Specifies whether a track should be eligible for automatic selection
+        :param forced:              Specifies whether a track should be played with tracks of a different type but same language
+
+        :param tags:                Any custom/arbitrary tags to set for the track.\n
+                                    An empty dict will remove any custom tags. `None` will do nothing.
+
+        :param kwargs:              Any other properties to set or remove.\n
+                                    Check out the 'Track headers' section in `mkvpropedit -l` to see what's available.
+        """
+        self._edit_track("s", self.subtitle_index, name, language, default, forced, tags, **kwargs)
+        self.subtitle_index += 1
+        return self
+
+    def run(self, quiet: bool = True, error_on_failure: bool = True) -> bool:
+        """
+        Run the mkvpropedit process.
+
+        :param quiet:               Supresses the output.\n
+                                    The stdout will still be printed on failure regardless of this setting.
+
+        :param error_on_failure:    Raise an exception on failure.\n
+                                    Otherwise this function will return a bool indicating the success.
+        """
+        args = [str(self.executable), str(self.fileIn)] + self.main_args + self.track_args
+        code = run_commandline(args, quiet, mkvmerge=True)
+
+        if code > 1 and error_on_failure:
+            raise error(f"Failed to edit properties for '{self.fileIn.name}'!")
+
+        return code < 2

--- a/muxtools/helpers/propedit.py
+++ b/muxtools/helpers/propedit.py
@@ -258,7 +258,7 @@ class MKVPropEdit:
         """
         Run the mkvpropedit process.
 
-        :param quiet:               Supresses the output.\n
+        :param quiet:               Suppresses the output.\n
                                     The stdout will still be printed on failure regardless of this setting.
 
         :param error_on_failure:    Raise an exception on failure.\n

--- a/muxtools/helpers/propedit.py
+++ b/muxtools/helpers/propedit.py
@@ -33,7 +33,7 @@ class MKVPropEdit:
                                     It can also take a muxtools Chapters object and create a txt from that.\n
                                     An empty string will remove any chapters. `None` will do nothing.
 
-        :param tags:                Global tags to add or replace.\n
+        :param tags:                Global tags to add. This will replace all custom tags set before.\n
                                     An empty dict will remove any global tags. `None` will do nothing.
         """
         self._executable = ensure_path(get_executable("mkvpropedit"), self)
@@ -159,6 +159,7 @@ class MKVPropEdit:
         :param forced:              Specifies whether a track should be played with tracks of a different type but same language
 
         :param tags:                Any custom/arbitrary tags to set for the track.\n
+                                    Do note that this will replace all custom tags the track may already have.\n
                                     An empty dict will remove any custom tags. `None` will do nothing.
 
         :param kwargs:              Any other properties to set or remove.\n
@@ -189,6 +190,7 @@ class MKVPropEdit:
         :param forced:              Specifies whether a track should be played with tracks of a different type but same language
 
         :param tags:                Any custom/arbitrary tags to set for the track.\n
+                                    Do note that this will replace all custom tags the track may already have.\n
                                     An empty dict will remove any custom tags. `None` will do nothing.
 
         :param kwargs:              Any other properties to set or remove.\n
@@ -219,6 +221,7 @@ class MKVPropEdit:
         :param forced:              Specifies whether a track should be played with tracks of a different type but same language
 
         :param tags:                Any custom/arbitrary tags to set for the track.\n
+                                    Do note that this will replace all custom tags the track may already have.\n
                                     An empty dict will remove any custom tags. `None` will do nothing.
 
         :param kwargs:              Any other properties to set or remove.\n

--- a/muxtools/utils/files.py
+++ b/muxtools/utils/files.py
@@ -123,8 +123,7 @@ def create_tags_xml(fileOut: PathLike, tags: dict[str, Any]) -> None:
         value = ET.SubElement(simple, "String")
         value.text = str(v)
 
-    with open(fileOut, "w") as f:
-        ET.ElementTree(main).write(f, "utf-8")
+    ET.ElementTree(main).write(fileOut, "utf-8")
 
 
 def make_output(source: PathLike, ext: str, suffix: str = "", user_passed: PathLike | None = None, temp: bool = False) -> Path:

--- a/muxtools/utils/files.py
+++ b/muxtools/utils/files.py
@@ -124,7 +124,7 @@ def create_tags_xml(fileOut: PathLike, tags: dict[str, Any]) -> None:
         value.text = str(v)
 
     with open(fileOut, "w") as f:
-        ET.ElementTree(main).write(f, "unicode")
+        ET.ElementTree(main).write(f, "utf-8")
 
 
 def make_output(source: PathLike, ext: str, suffix: str = "", user_passed: PathLike | None = None, temp: bool = False) -> Path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     "psutil>=5.6.4",
     "videotimestamps>=0.2.0",
     "typed-ffmpeg-compatible==3.6.0",
-    "mkvinfo==0.0.2"
+    "mkvinfo==0.0.2",
+    "typing-extensions>=4.12.0"
 ]
 classifiers = [
     "Natural Language :: English",

--- a/tests/helpers/test_bsf_avc_hevc.py
+++ b/tests/helpers/test_bsf_avc_hevc.py
@@ -1,0 +1,120 @@
+from muxtools import ensure_path, Setup, get_workdir, ParsedFile
+from muxtools.helpers.bsf import (
+    BSF_Format,
+    BSF_Matrix,
+    BSF_Primaries,
+    BSF_Transfer,
+    BSF_ChromaLocation,
+    apply_hevc_bsf,
+    apply_avc_bsf,
+)
+from time import sleep
+from shutil import rmtree, copy
+import pytest
+
+
+test_dir = ensure_path(__file__, None).parent.parent
+sample_file_h264 = test_dir / "test-data" / "sample-files" / "H264-PCM-sample.m2ts"
+sample_file_h265 = test_dir / "test-data" / "sample-files" / "H265-Opus-AAC-sample.mkv"
+
+
+@pytest.fixture(autouse=True)
+def setup_and_remove():
+    Setup("Test", None)
+
+    copy(sample_file_h264, get_workdir() / "Test_h264.m2ts")
+    copy(sample_file_h265, get_workdir() / "Test_h265.mkv")
+
+    yield
+
+    sleep(0.1)
+    rmtree(get_workdir())
+
+
+def test_nothing_ever_happens():
+    with pytest.raises(Exception, match="avc"):
+        apply_avc_bsf(get_workdir() / "Test_h264.m2ts")
+    with pytest.raises(Exception, match="hevc"):
+        apply_hevc_bsf(get_workdir() / "Test_h265.mkv")
+
+
+def test_apply_avc_bsf():
+    f = get_workdir() / "Test_h264.m2ts"
+    apply_avc_bsf(
+        f,
+        sar=1,
+        cloc_type=2,
+        full_range=True,
+        format=BSF_Format.NTSC,
+        primaries=BSF_Primaries.SMPTE170M,
+        transfer=BSF_Transfer.BT601,
+        matrix=BSF_Matrix.SMPTE170M,
+    )
+
+    original = ParsedFile.from_file(sample_file_h264).tracks[0].raw_ffprobe
+    new = ParsedFile.from_file(f).tracks[0].raw_ffprobe
+
+    assert not original.color_transfer and new.color_transfer == "smpte170m"
+    assert not original.color_primaries and new.color_primaries == "smpte170m"
+    assert not original.color_space and new.color_space == "smpte170m"
+    assert not original.color_range and new.color_range == "pc"
+    assert original.chroma_location == "left"
+    assert new.chroma_location == "topleft"
+
+
+def test_apply_hevc_bsf():
+    f = get_workdir() / "Test_h265.mkv"
+    apply_hevc_bsf(
+        f,
+        sar=1,
+        cloc_type=BSF_ChromaLocation.CENTER,
+        full_range=True,
+        format=BSF_Format.NTSC,
+        primaries=BSF_Primaries.SMPTE170M,
+        transfer=BSF_Transfer.BT601,
+        matrix=BSF_Matrix.SMPTE170M,
+    )
+
+    original = ParsedFile.from_file(sample_file_h265).tracks[0].raw_ffprobe
+    new = ParsedFile.from_file(f).tracks[0].raw_ffprobe
+
+    assert original.color_transfer == "bt709" and new.color_transfer == "smpte170m"
+    assert original.color_primaries == "bt709" and new.color_primaries == "smpte170m"
+    assert original.color_space == "bt709" and new.color_space == "smpte170m"
+    assert original.color_range == "tv" and new.color_range == "pc"
+    assert original.chroma_location == "left"
+    assert new.chroma_location == "center"
+
+
+def test_chromalocs():
+    for cloc in BSF_ChromaLocation:
+        f = get_workdir() / "Test_h265.mkv"
+        apply_hevc_bsf(f, cloc_type=cloc)
+
+        new = ParsedFile.from_file(f).tracks[0].raw_ffprobe
+
+        assert new.chroma_location == cloc.name.lower().replace("_", "")
+
+    for cloc in BSF_ChromaLocation:
+        f = get_workdir() / "Test_h264.m2ts"
+        apply_avc_bsf(f, cloc_type=cloc)
+
+        new = ParsedFile.from_file(f).tracks[0].raw_ffprobe
+
+        assert new.chroma_location == cloc.name.lower().replace("_", "")
+
+
+def test_crops():
+    f = get_workdir() / "Test_h265.mkv"
+    apply_hevc_bsf(f, crop=2)
+
+    new = ParsedFile.from_file(f).tracks[0].raw_ffprobe
+    assert new.width == 1916
+    assert new.height == 1076
+
+    f = get_workdir() / "Test_h264.m2ts"
+    apply_avc_bsf(f, crop=2)
+
+    new = ParsedFile.from_file(f).tracks[0].raw_ffprobe
+    assert new.width == 1916
+    assert new.height == 1084  # AVC has internal mod16 padding

--- a/tests/helpers/test_bsf_mpeg2.py
+++ b/tests/helpers/test_bsf_mpeg2.py
@@ -1,0 +1,86 @@
+from muxtools import ensure_path, Setup, get_workdir, ParsedFile
+from muxtools.helpers.bsf import apply_mpeg2_bsf, BSF_Format, BSF_Matrix, BSF_Primaries, BSF_Transfer, MPEG2_DAR, MPEG2_FPS
+from time import sleep
+from shutil import rmtree, copy
+import pytest
+
+
+test_dir = ensure_path(__file__, None).parent.parent
+sample_file = test_dir / "test-data" / "sample-files" / "H262-DTS-ES-sample.m2ts"
+
+
+@pytest.fixture(autouse=True)
+def setup_and_remove():
+    Setup("Test", None)
+    f = get_workdir() / "Test.m2ts"
+
+    copy(sample_file, f)
+
+    yield
+
+    sleep(0.1)
+    rmtree(get_workdir())
+
+
+def test_invalid_values():
+    f = get_workdir() / "Test.m2ts"
+    for transfer in [BSF_Transfer.LOG100, BSF_Transfer.HLG, BSF_Transfer.BT2020_10]:
+        failed = False
+
+        try:
+            apply_mpeg2_bsf(f, transfer=transfer)
+        except:
+            failed = True
+
+        assert failed
+
+    for matrix in [BSF_Matrix.RGB, BSF_Matrix.YCGCO]:
+        failed = False
+
+        try:
+            apply_mpeg2_bsf(f, matrix=matrix)
+        except:
+            failed = True
+
+        assert failed
+
+    for primaries in [BSF_Primaries.FILM, BSF_Primaries.BT2020]:
+        failed = False
+
+        try:
+            apply_mpeg2_bsf(f, primaries=primaries)
+        except:
+            failed = True
+
+        assert failed
+
+
+def test_nothing_ever_happens():
+    f = get_workdir() / "Test.m2ts"
+    failed = False
+    try:
+        apply_mpeg2_bsf(f)
+    except:
+        failed = True
+    assert failed
+
+
+def test_apply():
+    f = get_workdir() / "Test.m2ts"
+    apply_mpeg2_bsf(
+        f,
+        dar=MPEG2_DAR.DAR_16_9,
+        fps=MPEG2_FPS.FPS_25,
+        format=BSF_Format.NTSC,
+        primaries=BSF_Primaries.SMPTE170M,
+        transfer=BSF_Transfer.BT601,
+        matrix=BSF_Matrix.SMPTE170M,
+    )
+
+    original = ParsedFile.from_file(sample_file).tracks[0].raw_ffprobe
+    new = ParsedFile.from_file(f).tracks[0].raw_ffprobe
+
+    assert not original.color_transfer and new.color_transfer == "smpte170m"
+    assert not original.color_primaries and new.color_primaries == "smpte170m"
+    assert not original.color_space and new.color_space == "smpte170m"
+    assert original.avg_frame_rate != new.avg_frame_rate and new.avg_frame_rate == "25/1"

--- a/tests/helpers/test_bsf_mpeg2.py
+++ b/tests/helpers/test_bsf_mpeg2.py
@@ -25,44 +25,22 @@ def setup_and_remove():
 def test_invalid_values():
     f = get_workdir() / "Test.m2ts"
     for transfer in [BSF_Transfer.LOG100, BSF_Transfer.HLG, BSF_Transfer.BT2020_10]:
-        failed = False
-
-        try:
+        with pytest.raises(Exception):
             apply_mpeg2_bsf(f, transfer=transfer)
-        except:
-            failed = True
-
-        assert failed
 
     for matrix in [BSF_Matrix.RGB, BSF_Matrix.YCGCO]:
-        failed = False
-
-        try:
+        with pytest.raises(Exception):
             apply_mpeg2_bsf(f, matrix=matrix)
-        except:
-            failed = True
-
-        assert failed
 
     for primaries in [BSF_Primaries.FILM, BSF_Primaries.BT2020]:
-        failed = False
-
-        try:
+        with pytest.raises(Exception):
             apply_mpeg2_bsf(f, primaries=primaries)
-        except:
-            failed = True
-
-        assert failed
 
 
 def test_nothing_ever_happens():
     f = get_workdir() / "Test.m2ts"
-    failed = False
-    try:
+    with pytest.raises(Exception):
         apply_mpeg2_bsf(f)
-    except:
-        failed = True
-    assert failed
 
 
 def test_apply():

--- a/tests/helpers/test_mkvpropedit.py
+++ b/tests/helpers/test_mkvpropedit.py
@@ -12,7 +12,7 @@ def setup_and_remove():
 
     yield
 
-    sleep(0.5)
+    sleep(0.1)
     rmtree(get_workdir())
 
 
@@ -31,13 +31,9 @@ def test_mkvpropedit():
         .run()
     )
 
-    no_chapters = False
-    try:
+    with pytest.raises(Exception):
         Chapters.from_mkv(f)
-    except:
-        no_chapters = True
 
-    assert no_chapters
     assert Chapters.from_mkv(sample_file, _print=False)
 
     original = ParsedFile.from_file(sample_file)

--- a/tests/helpers/test_mkvpropedit.py
+++ b/tests/helpers/test_mkvpropedit.py
@@ -13,7 +13,7 @@ def setup_and_remove():
     yield
 
     sleep(0.5)
-    # rmtree(get_workdir())
+    rmtree(get_workdir())
 
 
 def test_mkvpropedit():
@@ -64,18 +64,6 @@ def test_mkvpropedit_crops():
 
     copy(sample_file, f)
 
-    MKVPropEdit(f).video_track(crop=(1, 2, 3, 4)).run()
-    parsed = ParsedFile.from_file(f)
-    assert parsed.tracks[0].raw_ffprobe.side_data_list
-
-    side_data = parsed.tracks[0].raw_ffprobe.side_data_list.side_data[0]
-    assert side_data.type == "Frame Cropping"
-    assert [data for data in side_data.side_datum if data.key == "crop_left"][0].value == "1"
-    assert [data for data in side_data.side_datum if data.key == "crop_top"][0].value == "2"
-    assert [data for data in side_data.side_datum if data.key == "crop_right"][0].value == "3"
-    assert [data for data in side_data.side_datum if data.key == "crop_bottom"][0].value == "4"
-
-    # Full crop
     MKVPropEdit(f).video_track(crop=(1, 2, 3, 4)).run()
     parsed = ParsedFile.from_file(f)
     assert parsed.tracks[0].raw_ffprobe.side_data_list

--- a/tests/helpers/test_mkvpropedit.py
+++ b/tests/helpers/test_mkvpropedit.py
@@ -1,0 +1,57 @@
+from muxtools import ensure_path, MKVPropEdit, Setup, get_workdir, Chapters, ParsedFile
+from time import sleep
+from shutil import rmtree, copy
+import pytest
+
+test_dir = ensure_path(__file__, None).parent.parent
+
+
+@pytest.fixture(autouse=True)
+def setup_and_remove():
+    Setup("Test", None)
+
+    yield
+
+    sleep(0.5)
+    rmtree(get_workdir())
+
+
+def test_mkvpropedit():
+    sample_file = test_dir / "test-data" / "sample-files" / "H265-Opus-AAC-sample.mkv"
+    f = get_workdir() / "Test.mkv"
+
+    copy(sample_file, f)
+
+    (
+        MKVPropEdit(f, chapters="", tags=dict(TVDB="111111"))
+        .video_track("Yapper Encode", "de", True, False)
+        .audio_track("Yappernese", "und", False, True, tags=dict(ENCODER="not opus"))
+        .audio_track("English 5.1 (edited)", "en")
+        .audio_track("German 2.0 (edited)", "de")
+        .run()
+    )
+
+    no_chapters = False
+    try:
+        Chapters.from_mkv(f)
+    except:
+        no_chapters = True
+
+    assert no_chapters
+    assert Chapters.from_mkv(sample_file, _print=False)
+
+    original = ParsedFile.from_file(sample_file)
+    new = ParsedFile.from_file(f)
+
+    assert "TMDB" in original.container_info.tags
+    assert "TMDB" not in new.container_info.tags
+    assert original.tracks[0].title != new.tracks[0].title
+    assert original.tracks[0].language != new.tracks[0].language
+
+    assert original.tracks[1].title != new.tracks[1].title
+    assert original.tracks[1].language != new.tracks[1].language
+    assert "ENCODER_SETTINGS" not in new.tracks[1].other_tags and "ENCODER_SETTINGS" in original.tracks[1].other_tags
+    assert new.tracks[1].other_tags.get("ENCODER") != original.tracks[1].other_tags.get("ENCODER")
+
+    assert original.tracks[2].title != new.tracks[2].title
+    assert original.tracks[3].title != new.tracks[3].title

--- a/tests/helpers/test_mkvpropedit.py
+++ b/tests/helpers/test_mkvpropedit.py
@@ -13,7 +13,7 @@ def setup_and_remove():
     yield
 
     sleep(0.5)
-    rmtree(get_workdir())
+    # rmtree(get_workdir())
 
 
 def test_mkvpropedit():
@@ -23,10 +23,10 @@ def test_mkvpropedit():
     copy(sample_file, f)
 
     (
-        MKVPropEdit(f, chapters="", tags=dict(TVDB="111111"))
+        MKVPropEdit(f, chapters="", tags=dict(TVDB="111111", TMDB=""))
         .video_track("Yapper Encode", "de", True, False)
-        .audio_track("Yappernese", "und", False, True, tags=dict(ENCODER="not opus"))
-        .audio_track("English 5.1 (edited)", "en")
+        .audio_track("Yappernese", "und", False, True, tags=dict(ENCODER="not opus", ENCODER_SETTINGS=""))
+        .audio_track("English 5.1 (edited)", "en", tags=dict(ENCODER="not qaac"))
         .audio_track("German 2.0 (edited)", "de")
         .run()
     )
@@ -53,5 +53,62 @@ def test_mkvpropedit():
     assert "ENCODER_SETTINGS" not in new.tracks[1].other_tags and "ENCODER_SETTINGS" in original.tracks[1].other_tags
     assert new.tracks[1].other_tags.get("ENCODER") != original.tracks[1].other_tags.get("ENCODER")
 
+    assert new.tracks[2].other_tags.get("ENCODER") != original.tracks[2].other_tags.get("ENCODER")
     assert original.tracks[2].title != new.tracks[2].title
     assert original.tracks[3].title != new.tracks[3].title
+
+
+def test_mkvpropedit_crops():
+    sample_file = test_dir / "test-data" / "sample-files" / "H265-Opus-AAC-sample.mkv"
+    f = get_workdir() / "Test.mkv"
+
+    copy(sample_file, f)
+
+    MKVPropEdit(f).video_track(crop=(1, 2, 3, 4)).run()
+    parsed = ParsedFile.from_file(f)
+    assert parsed.tracks[0].raw_ffprobe.side_data_list
+
+    side_data = parsed.tracks[0].raw_ffprobe.side_data_list.side_data[0]
+    assert side_data.type == "Frame Cropping"
+    assert [data for data in side_data.side_datum if data.key == "crop_left"][0].value == "1"
+    assert [data for data in side_data.side_datum if data.key == "crop_top"][0].value == "2"
+    assert [data for data in side_data.side_datum if data.key == "crop_right"][0].value == "3"
+    assert [data for data in side_data.side_datum if data.key == "crop_bottom"][0].value == "4"
+
+    # Full crop
+    MKVPropEdit(f).video_track(crop=(1, 2, 3, 4)).run()
+    parsed = ParsedFile.from_file(f)
+    assert parsed.tracks[0].raw_ffprobe.side_data_list
+
+    side_data = parsed.tracks[0].raw_ffprobe.side_data_list.side_data[0]
+    assert side_data.type == "Frame Cropping"
+    assert [data for data in side_data.side_datum if data.key == "crop_left"][0].value == "1"
+    assert [data for data in side_data.side_datum if data.key == "crop_top"][0].value == "2"
+    assert [data for data in side_data.side_datum if data.key == "crop_right"][0].value == "3"
+    assert [data for data in side_data.side_datum if data.key == "crop_bottom"][0].value == "4"
+
+    # Crop 2 horizontally, 4 vertically
+    MKVPropEdit(f).video_track(crop=(2, 4)).run()
+    parsed = ParsedFile.from_file(f)
+    assert parsed.tracks[0].raw_ffprobe.side_data_list
+
+    side_data = parsed.tracks[0].raw_ffprobe.side_data_list.side_data[0]
+    assert side_data.type == "Frame Cropping"
+    assert [data for data in side_data.side_datum if data.key == "crop_left"][0].value == "2"
+    assert [data for data in side_data.side_datum if data.key == "crop_right"][0].value == "2"
+    assert [data for data in side_data.side_datum if data.key == "crop_top"][0].value == "4"
+    assert [data for data in side_data.side_datum if data.key == "crop_bottom"][0].value == "4"
+
+    # Crop 4 on all sides
+    MKVPropEdit(f).video_track(crop=4).run()
+    parsed = ParsedFile.from_file(f)
+    assert parsed.tracks[0].raw_ffprobe.side_data_list
+
+    side_data = parsed.tracks[0].raw_ffprobe.side_data_list.side_data[0]
+    assert side_data.type == "Frame Cropping"
+    assert len([data for data in side_data.side_datum if data.value == "4"]) == 4
+
+    # Crop removed
+    MKVPropEdit(f).video_track(crop=0).run()
+    parsed = ParsedFile.from_file(f)
+    assert not parsed.tracks[0].raw_ffprobe.side_data_list

--- a/tests/parsing/test_track_finding.py
+++ b/tests/parsing/test_track_finding.py
@@ -56,11 +56,5 @@ def test_find_custom_condition(parsed_file):
 
 
 def test_error_on_empty(parsed_file):
-    failed = False
-
-    try:
+    with pytest.raises(Exception):
         parsed_file.find_tracks(custom_condition=lambda track: track.get_audio_format() == AudioFormat.FLAC, error_if_empty=True)
-    except:
-        failed = True
-
-    assert failed

--- a/tests/test_full_merge.py
+++ b/tests/test_full_merge.py
@@ -16,7 +16,7 @@ def setup_and_remove():
 
     yield
 
-    sleep(0.5)  # Just in case there's still a lock on some file lol
+    sleep(0.1)
     rmtree(get_workdir())
 
 

--- a/tests/test_sub_mismatch_warn.py
+++ b/tests/test_sub_mismatch_warn.py
@@ -12,7 +12,7 @@ def setup_and_remove():
 
     yield
 
-    sleep(0.5)  # Just in case there's still a lock on some file lol
+    sleep(0.1)
     rmtree(get_workdir())
 
 
@@ -54,11 +54,6 @@ def test_error_on_danger() -> None:
 
     sub = SubFile(test_dir / "test-data" / "input" / "vigilantes_s01e01_en.ass")
     other = sub.copy(get_workdir() / "vigilantes_s01e01_en_mismatched_playres").set_headers((ASSHeader.PlayResX, 1280), (ASSHeader.PlayResY, 720))
-    failed = False
-    try:
-        sub.merge(other)
-        failed = False
-    except:
-        failed = True
 
-    assert failed
+    with pytest.raises(Exception):
+        sub.merge(other)

--- a/tests/test_sub_shifting.py
+++ b/tests/test_sub_shifting.py
@@ -15,7 +15,7 @@ def setup_and_remove():
 
     yield
 
-    sleep(0.5)  # Just in case there's still a lock on some file lol
+    sleep(0.1)
     rmtree(get_workdir())
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -587,6 +587,7 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "typed-ffmpeg-compatible" },
+    { name = "typing-extensions" },
     { name = "videotimestamps" },
     { name = "wget" },
 ]
@@ -611,6 +612,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.31.0" },
     { name = "rich", specifier = ">=13.1.0" },
     { name = "typed-ffmpeg-compatible", specifier = "==3.6.0" },
+    { name = "typing-extensions", specifier = ">=4.12.0" },
     { name = "videotimestamps", specifier = ">=0.2.0" },
     { name = "wget", specifier = ">=3.2" },
 ]


### PR DESCRIPTION
Adds the following:

* [MKVPropEdit](https://mkvtoolnix.download/doc/mkvpropedit.html) Helper
  See Usage in the [tests](https://github.com/Jaded-Encoding-Thaumaturgy/muxtools/blob/836f87833d34bb8c7182cb42a53067b98c47da8b/tests/helpers/test_mkvpropedit.py)
* [mpeg2_metadata](https://ffmpeg.org/ffmpeg-bitstream-filters.html#mpeg2_005fmetadata) bitstream filter helper
  See Usage in the [tests](https://github.com/Jaded-Encoding-Thaumaturgy/muxtools/blob/836f87833d34bb8c7182cb42a53067b98c47da8b/tests/helpers/test_bsf_mpeg2.py)
* [h264_metadata](https://ffmpeg.org/ffmpeg-bitstream-filters.html#h264_005fmetadata) bitstream filter helper
  See Usage in the [tests](https://github.com/Jaded-Encoding-Thaumaturgy/muxtools/blob/836f87833d34bb8c7182cb42a53067b98c47da8b/tests/helpers/test_bsf_avc_hevc.py#L41)
* [hevc_metadata](https://ffmpeg.org/ffmpeg-bitstream-filters.html#hevc_005fmetadata) bitstream filter helper
  See Usage in the [tests](https://github.com/Jaded-Encoding-Thaumaturgy/muxtools/blob/836f87833d34bb8c7182cb42a53067b98c47da8b/tests/helpers/test_bsf_avc_hevc.py#L65)