### PR TITLE
add subset_fonts func

### DIFF
--- a/muxtools/subtitle/__init__.py
+++ b/muxtools/subtitle/__init__.py
@@ -9,3 +9,4 @@ from .sub_pgs import *
 from .styles import *
 from .subutils import *
 from .basesub import *
+from .font import *

--- a/muxtools/subtitle/font.py
+++ b/muxtools/subtitle/font.py
@@ -57,9 +57,19 @@ COMMON_UNICODE_CHARS = _parse_unicode_chars(UNFORMATTED_COMMON_UNICODE_CHARS)
 
 
 def _hash_font_name(font_name: str, run_time: str) -> str:
-    return base64.urlsafe_b64encode(
+    font_name = font_name.replace(" ", "").strip()
+
+    # Font names should be at most 31 characters long to work with GDI
+
+    hash = base64.urlsafe_b64encode(
         hashlib.sha256(f"{font_name}_Subset_{run_time}".encode('utf-8')).digest()
-    ).decode('utf-8').replace("=", "")[:31]
+    ).decode('utf-8').replace("=", "")
+
+    # Maximise the hash we can use, whilst keeping the total length <= 31 and a decent size hash (6 chars at least)
+    if len(font_name) > 24:
+        return f"{font_name[:24]}_{hash[:6]}"
+    else:
+        return f"{font_name}_{hash[:(31 - len(font_name) - 1)]}"
 
 
 def subset_fonts(

--- a/muxtools/subtitle/font.py
+++ b/muxtools/subtitle/font.py
@@ -174,16 +174,22 @@ def subset_fonts(
                 old_name = record.toUnicode().strip()
                 if old_name in data["names"]:
                     record.string = data["names"][old_name]
+                else:
+                    raise Exception(f"Font family name '{old_name}' not found in names mapping for font '{font_name}'!")
             
             elif record.nameID == 4:  # Full name
                 old_name = record.toUnicode().strip()
                 if old_name in data["names"]:
                     record.string = data["names"][old_name]
+                else:
+                    raise Exception(f"Font full name '{old_name}' not found in names mapping for font '{font_name}'!")
             
             elif record.nameID == 6:  # PostScript name
                 old_name = record.toUnicode().strip()
                 if old_name in data["names"]:
                     record.string = data["names"][old_name]
+                else:
+                    raise Exception(f"Font PostScript name '{old_name}' not found in names mapping for font '{font_name}'!")
         
         characters = data["usage"].copy()
         characters.update(subset_additional_glyphs_parsed)

--- a/muxtools/subtitle/font.py
+++ b/muxtools/subtitle/font.py
@@ -18,15 +18,10 @@ from ..utils.log import warn, error, info, danger, log_escape
 # For ranges, use 'U+XXXX-YYYY'
 UNFORMATTED_COMMON_UNICODE_CHARS = [
     'U+0000-00FF',  # Basic Latin + Latin-1 Supplement
-    'U+0100-017F',  # Latin Extended-A
+    'U+0100-024F',  # Latin Extended-A + Latin Extended-B
+    'U+1E00-1EFF',  # Latin Extended Additional
     'U+2000-206F',  # General Punctuation
     'U+20A0-20CF',  # Currency Symbols
-
-    # Accent exceptions
-    'U+0150', # O Double acute accent
-    'U+0151', # o Double acute accent
-    'U+0170', # U Double acute accent
-    'U+0171', # u Double acute accent
 ]
 
 def _parse_unicode_chars(char_list: list[str]) -> list[str]:

--- a/muxtools/subtitle/font.py
+++ b/muxtools/subtitle/font.py
@@ -241,9 +241,10 @@ def subset_fonts(
 
                         if data.name in font_replacements:
                             event.text = re.sub(
-                                R'(\\fn.*)(' + safe_font_name + R')(.*)',
-                                lambda m: m.group(1) + font_replacements[data.name] + m.group(3),
-                                event.text
+                                R'(\\fn[^\\}]*)' + safe_font_name,
+                                lambda m: m.group(1) + font_replacements[data.name],
+                                event.text,
+                                count=1
                             )
                             modified = True
             

--- a/muxtools/subtitle/font.py
+++ b/muxtools/subtitle/font.py
@@ -181,6 +181,8 @@ def collect_fonts(
                         new_size = os.path.getsize(new_path)
                         info(f"Subsetted font '{fontname}' ({len(characters)} glyphs, {sizeof_fmt(old_size)} -> {sizeof_fmt(new_size)})", collect_fonts)
 
+                        outpath = new_path
+
             
             found_fonts.append(MTFontFile(outpath))
 

--- a/muxtools/subtitle/font.py
+++ b/muxtools/subtitle/font.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from font_collector import ABCFontFace, VariableFontFace
 from fontTools.subset import Subsetter
 from fontTools import ttLib
-import time
 import hashlib
 import base64
 

--- a/muxtools/subtitle/font.py
+++ b/muxtools/subtitle/font.py
@@ -4,9 +4,11 @@ import shutil
 import logging
 from collections import defaultdict
 from pathlib import Path
-from font_collector import ABCFontFace, VariableFontFace
-from fontTools.subset import Subsetter
-from fontTools import ttLib
+from typing import TypedDict
+from font_collector import ABCFontFace, VariableFontFace  # type: ignore[import-untyped]
+from fontTools.subset import Subsetter  # type: ignore[import-untyped]
+from fontTools import ttLib  # type: ignore[import-untyped]
+from fontTools.ttLib.ttCollection import TTCollection  # type: ignore[import-untyped]
 import hashlib
 import base64
 
@@ -19,6 +21,12 @@ from ..utils.log import warn, error, info, danger, debug
 __all__ = [
     "subset_fonts",
 ]
+
+
+class _FontData(TypedDict):
+    usage: set[str]
+    names: set[str]
+    names_hashed: dict[str, str]
 
 # A selection of common unicode characters to always include when subsetting fonts
 # Follows the format: 'U+XXXX'
@@ -102,7 +110,7 @@ def subset_fonts(
 
     from font_collector import AssDocument, FontLoader, FontCollection, FontSelectionStrategyLibass, ABCFontFace
 
-    from ass_tag_analyzer import parse_line, AssValidTagFontName
+    from ass_tag_analyzer import parse_line, AssValidTagFontName  # type: ignore[import-untyped]
 
     font_collection = FontCollection(
         use_system_font=False,
@@ -114,11 +122,7 @@ def subset_fonts(
 
     subset_additional_glyphs_parsed = _parse_unicode_chars(additional_glyphs)
 
-    fonts: dict[ABCFontFace, dict[str, set[str] | dict[str, str]]] = {}
-    # Font:
-    # - usage: set()
-    # - names: set()  # old name
-    # - names_hashed: dict[str, str]  # old name -> new name
+    fonts: dict[ABCFontFace, _FontData] = {}
 
     for sub in subs:
         doc = AssDocument(sub._read_doc())
@@ -213,7 +217,6 @@ def subset_fonts(
 
         is_collection = len(faces_to_save) > 1 or source_file.suffix.lower() in ('.ttc', '.otc')
         if is_collection:
-            from fontTools.ttLib.ttCollection import TTCollection
             ttc = TTCollection()
             for _, f, _ in faces_to_save:
                 ttc.fonts.append(f)

--- a/muxtools/subtitle/font.py
+++ b/muxtools/subtitle/font.py
@@ -198,6 +198,10 @@ def subset_fonts(
                         fonts[font_face]["names_hashed"][old_name] = _hash_font_name(old_name, chars_sorted)
                     record.string = fonts[font_face]["names_hashed"][old_name]
 
+            # Mark as a muxtools subset via name ID 3 (unique font identifier).
+            # This lets font databases identify and group/skip subset fonts.
+            name_table.setName(f"muxtools-subset;{font_name};{_hash_font_name(font_name, chars_sorted)}", 3, 3, 1, 0x0409)
+
             subsetter = Subsetter()
             subsetter.populate(text="".join(characters))
             subsetter.subset(ttLib_font)

--- a/muxtools/subtitle/font.py
+++ b/muxtools/subtitle/font.py
@@ -2,6 +2,7 @@ import os
 import re
 import shutil
 import logging
+from collections import defaultdict
 from pathlib import Path
 from font_collector import ABCFontFace, VariableFontFace
 from fontTools.subset import Subsetter
@@ -13,7 +14,7 @@ import base64
 from .sub import SubFile, FontFile as MTFontFile
 from ..utils.convert import sizeof_fmt
 from ..utils.env import get_workdir
-from ..utils.log import warn, error, info, danger
+from ..utils.log import warn, error, info, danger, debug
 
 
 __all__ = [
@@ -114,7 +115,7 @@ def subset_fonts(
 
     subset_additional_glyphs_parsed = _parse_unicode_chars(additional_glyphs)
 
-    fonts: dict[ABCFontFace, dict] = {}
+    fonts: dict[ABCFontFace, dict[str, set[str] | dict[str, str]]] = {}
     # Font:
     # - usage: set()
     # - names: set()  # old name
@@ -151,73 +152,96 @@ def subset_fonts(
     total_old_size = 0
     total_new_size = 0
 
+    # Group font faces by source file so TTC collections are handled atomically
+    faces_by_file: dict[Path, list[ABCFontFace]] = defaultdict(list)
     for font_face in fonts.keys():
         assert font_face.font_file is not None, "Font file is missing!"
+        faces_by_file[Path(font_face.font_file.filename)].append(font_face)
 
-        font_name = _get_fontname(font_face)
+    for source_file, face_list in faces_by_file.items():
+        # (font_face, loaded TTFont, character count) for faces we will save
+        faces_to_save: list[tuple[ABCFontFace, ttLib.TTFont, int]] = []
 
-        # Old size is calculated before skipping subsetting if necessary
-        old_size = os.path.getsize(font_face.font_file.filename)
+        for font_face in face_list:
+            font_name = _get_fontname(font_face)
+
+            characters = fonts[font_face]["usage"].copy()
+            characters.update(subset_additional_glyphs_parsed)
+
+            if not aggressive:
+                characters.update(COMMON_UNICODE_CHARS)
+
+            if not characters:
+                if ignore_fonts_with_no_usage:
+                    warn(f"No characters used in font '{font_name}'. Skipping subsetting.", subset_fonts)
+                    continue
+                else:
+                    warn(f"No characters used in font '{font_name}'. Defaulting to common subset.", subset_fonts)
+                    characters.update(COMMON_UNICODE_CHARS)
+
+            chars_sorted = "".join(sorted(characters))
+            for old_name in fonts[font_face]["names"]:
+                fonts[font_face]["names_hashed"][old_name] = _hash_font_name(old_name, chars_sorted)
+
+            debug(f"Subsetting font '{source_file}' (index {font_face.font_index})...", subset_fonts)
+
+            ttLib_font = ttLib.TTFont(source_file, fontNumber=font_face.font_index)
+
+            name_table = ttLib_font["name"]
+            for record in name_table.names:
+                if record.nameID in [1, 4, 6]:  # Font Family name, Full name, PostScript name
+                    old_name = record.toUnicode().strip()
+                    if old_name not in fonts[font_face]["names_hashed"]:
+                        fonts[font_face]["names_hashed"][old_name] = _hash_font_name(old_name, chars_sorted)
+                    record.string = fonts[font_face]["names_hashed"][old_name]
+
+            subsetter = Subsetter()
+            subsetter.populate(text="".join(characters))
+            subsetter.subset(ttLib_font)
+
+            faces_to_save.append((font_face, ttLib_font, len(characters)))
+
+            for old_name, new_name in fonts[font_face]["names_hashed"].items():
+                font_replacements[old_name] = new_name
+
+        if not faces_to_save:
+            continue
+
+        old_size = os.path.getsize(source_file)
         total_old_size += old_size
 
-        # Determine which characters to include based on params and usage
-        characters = fonts[font_face]["usage"].copy()
-        characters.update(subset_additional_glyphs_parsed)
+        new_font_path = source_file.with_stem(f"{source_file.stem}_subset")
 
-        if not aggressive:
-            # We also want to add a general subset of common characters to avoid issues when reusing fonts, if we aren't doing aggressive subsetting
-            characters.update(COMMON_UNICODE_CHARS)
-
-        if not characters:
-            if ignore_fonts_with_no_usage:
-                warn(f"No characters used in font '{font_name}'. Skipping subsetting.", subset_fonts)
-                continue
-            else:
-                warn(f"No characters used in font '{font_name}'. Defaulting to common subset.", subset_fonts)
-                characters.update(COMMON_UNICODE_CHARS)
-        
-        chars_sorted = "".join(sorted(characters))
-        for old_name in fonts[font_face]["names"]:
-            fonts[font_face]["names_hashed"][old_name] = _hash_font_name(old_name, chars_sorted)
-
-        ttLib_font = ttLib.TTFont(font_face.font_file.filename)
-
-        name_table = ttLib_font["name"]
-
-        for record in name_table.names:
-            if record.nameID in [1, 4, 6]:  # Font Family name, Full name, PostScript name
-                old_name = record.toUnicode().strip()
-                if old_name not in fonts[font_face]["names_hashed"]: # If the name wasn't collected, hash it now
-                    fonts[font_face]["names_hashed"][old_name] = _hash_font_name(old_name, chars_sorted)
-                
-                record.string = fonts[font_face]["names_hashed"][old_name]
-        
-        subsetter = Subsetter()
-        subsetter.populate(text="".join(characters))
-        subsetter.subset(ttLib_font)
-
-        new_font_path = font_face.font_file.filename.with_stem(f"{font_face.font_file.filename.stem}_subset")
-        ttLib_font.save(new_font_path)
-        ttLib_font.close()
+        is_collection = len(faces_to_save) > 1 or source_file.suffix.lower() in ('.ttc', '.otc')
+        if is_collection:
+            from fontTools.ttLib.ttCollection import TTCollection
+            ttc = TTCollection()
+            for _, f, _ in faces_to_save:
+                ttc.fonts.append(f)
+            ttc.save(str(new_font_path))
+            for _, f, _ in faces_to_save:
+                f.close()
+        else:
+            _, ttLib_font, _ = faces_to_save[0]
+            ttLib_font.save(new_font_path)
+            ttLib_font.close()
 
         new_size = os.path.getsize(new_font_path)
         total_new_size += new_size
 
         try:
-            os.remove(font_face.font_file.filename)
+            os.remove(source_file)
         except FileNotFoundError:
-            pass # If the file is already missing, we can ignore this, bit weird though
+            pass
         except PermissionError:
-            error(f"Could not remove original font file '{font_face.font_file.filename}' due to permission error. Is it open in another program?", subset_fonts)
-        
-        for old_name, new_name in fonts[font_face]["names_hashed"].items():
-            font_replacements[old_name] = new_name
+            error(f"Could not remove original font file '{source_file}' due to permission error. Is it open in another program?", subset_fonts)
 
-        info(f"Subsetted font '{font_name}' ({len(characters)} glyphs, {sizeof_fmt(old_size)} -> {sizeof_fmt(new_size)})", collect_fonts)
+        for font_face, _, char_count in faces_to_save:
+            font_name = _get_fontname(font_face)
+            info(f"Subsetted font '{font_name}' ({char_count} glyphs, {sizeof_fmt(old_size)} -> {sizeof_fmt(new_size)})", collect_fonts)
     
 
     if font_replacements:
-
         for sub in subs:
             doc = sub._read_doc()
 

--- a/muxtools/subtitle/font.py
+++ b/muxtools/subtitle/font.py
@@ -240,7 +240,7 @@ def subset_fonts(
 
         for font_face, _, char_count in faces_to_save:
             font_name = _get_fontname(font_face)
-            info(f"Subsetted font '{font_name}' ({char_count} glyphs, {sizeof_fmt(old_size)} -> {sizeof_fmt(new_size)})", collect_fonts)
+            info(f"Subsetted font '{font_name}' ({char_count} glyphs, {sizeof_fmt(old_size)} -> {sizeof_fmt(new_size)})", subset_fonts)
     
 
     if font_replacements:
@@ -275,7 +275,7 @@ def subset_fonts(
             info(f"Updated font names in subfile '{sub.file.name}'", subset_fonts)
     
     if print_final_stats and total_old_size > 0:
-        info(f'Subsetting has saved {(total_old_size - total_new_size) / total_old_size * 100:.2f}% ({sizeof_fmt(total_old_size)} -> {sizeof_fmt(total_new_size)})')
+        info(f'Subsetting has saved {sizeof_fmt(total_old_size - total_new_size)} ({(total_old_size - total_new_size) / total_old_size * 100:.2f}%, {sizeof_fmt(total_old_size)} -> {sizeof_fmt(total_new_size)})', subset_fonts)
     
     found_fonts = list[MTFontFile]()
     for r in ["*.[tT][tT][fF]", "*.[oO][tT][fF]", "*.[tT][tT][cC]", "*.[oO][tT][cC]"]:

--- a/muxtools/subtitle/font.py
+++ b/muxtools/subtitle/font.py
@@ -348,6 +348,8 @@ def collect_fonts(
 
     found_fonts = list[MTFontFile]()
     collected_faces = set[ABCFontFace]()
+    # Track source path -> workdir copy so TTC files aren't duplicated per-face
+    copied_sources: dict[Path, Path] = {}
 
     for style, usage_data in styles.items():
         query = font_collection.get_used_font_by_style(style, load_strategy)
@@ -375,6 +377,16 @@ def collect_fonts(
                 if query.font_face in collected_faces:
                     continue
 
+                # If this source file was already copied (e.g. another face from the
+                # same TTC), reuse the existing copy instead of creating a duplicate.
+                if fontpath in copied_sources:
+                    outpath = copied_sources[fontpath]
+                elif not outpath.exists():
+                    shutil.copy(fontpath, outpath)
+                    copied_sources[fontpath] = outpath
+                else:
+                    copied_sources[fontpath] = outpath
+
             if query.font_face not in collected_faces:
                 info(f"Found font '{fontname}'.", collect_fonts)
                 collected_faces.add(query.font_face)
@@ -391,8 +403,6 @@ def collect_fonts(
             if len(missing_glyphs) != 0:
                 danger(f"'{fontname}' is missing the following glyphs: {missing_glyphs}", collect_fonts, 3)
 
-            if not outpath.exists():
-                shutil.copy(fontpath, outpath)
 
     for r in ["*.[tT][tT][fF]", "*.[oO][tT][fF]", "*.[tT][tT][cC]", "*.[oO][tT][cC]"]:
         for f in get_workdir().glob(r):

--- a/muxtools/subtitle/font.py
+++ b/muxtools/subtitle/font.py
@@ -4,7 +4,7 @@ import shutil
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import TypedDict
+from typing import TypedDict, cast
 from font_collector import ABCFontFace, VariableFontFace  # type: ignore[import-untyped]
 from fontTools.subset import Subsetter  # type: ignore[import-untyped]
 from fontTools import ttLib  # type: ignore[import-untyped]
@@ -258,7 +258,7 @@ def subset_fonts(
                         if data.name in font_replacements:
                             event.text = re.sub(
                                 R'(\\fn[^\\}]*)' + safe_font_name,
-                                lambda m: m.group(1) + font_replacements[data.name],
+                                lambda m: cast(str, m.group(1)) + font_replacements[data.name],
                                 event.text,
                                 count=1
                             )

--- a/muxtools/subtitle/font.py
+++ b/muxtools/subtitle/font.py
@@ -5,7 +5,7 @@ import logging
 from collections import defaultdict
 from pathlib import Path
 from typing import TypedDict, cast
-from font_collector import ABCFontFace, VariableFontFace  # type: ignore[import-untyped]
+from font_collector import ABCFontFace, VariableFontFace
 from fontTools.subset import Subsetter  # type: ignore[import-untyped]
 from fontTools import ttLib  # type: ignore[import-untyped]
 from fontTools.ttLib.ttCollection import TTCollection  # type: ignore[import-untyped]

--- a/muxtools/subtitle/font.py
+++ b/muxtools/subtitle/font.py
@@ -81,6 +81,7 @@ def subset_fonts(
     aggressive: bool = False,
     ignore_fonts_with_no_usage: bool = True,
     additional_glyphs: list[str] = [],
+    min_file_size_to_subset: int = 400 * 1024,
     print_final_stats: bool = True,
 ) -> list[MTFontFile]:
     """
@@ -97,6 +98,7 @@ def subset_fonts(
     :param additional_glyphs:           If you have any additional glyphs that need to be included in the subsetted fonts.
                                         You can use the format "U+XXXX" for unicode characters or "U+XXXX-YYYY" for unicode ranges.
                                         https://unicode-explorer.com/blocks can help you find the characters/ranges you need.
+    :param min_file_size_to_subset:     Only subset fonts whose file size is at least this many bytes. Smaller fonts are left as-is. Set to 0 to subset all fonts regardless of size.
     :param print_final_stats:           If enabled, will print out statistics about space saved.
 
     :return:                            A list of FontFile objects
@@ -162,6 +164,13 @@ def subset_fonts(
         faces_by_file[Path(font_face.font_file.filename)].append(font_face)
 
     for source_file, face_list in faces_by_file.items():
+        file_size = os.path.getsize(source_file)
+        if file_size < min_file_size_to_subset:
+            debug(f"Skipping subsetting for '{source_file}' ({sizeof_fmt(file_size)} < {sizeof_fmt(min_file_size_to_subset)})", subset_fonts)
+            total_old_size += file_size
+            total_new_size += file_size
+            continue
+
         # (font_face, loaded TTFont, character count) for faces we will save
         faces_to_save: list[tuple[ABCFontFace, ttLib.TTFont, int]] = []
 

--- a/muxtools/subtitle/font.py
+++ b/muxtools/subtitle/font.py
@@ -28,31 +28,33 @@ class _FontData(TypedDict):
     names: set[str]
     names_hashed: dict[str, str]
 
+
 # A selection of common unicode characters to always include when subsetting fonts
 # Follows the format: 'U+XXXX'
 # For ranges, use 'U+XXXX-YYYY'
 UNFORMATTED_COMMON_UNICODE_CHARS = [
-    'U+0000-00FF',  # Basic Latin + Latin-1 Supplement
-    'U+0100-024F',  # Latin Extended-A + Latin Extended-B
-    'U+1E00-1EFF',  # Latin Extended Additional
-    'U+2000-206F',  # General Punctuation
-    'U+20A0-20CF',  # Currency Symbols
+    "U+0000-00FF",  # Basic Latin + Latin-1 Supplement
+    "U+0100-024F",  # Latin Extended-A + Latin Extended-B
+    "U+1E00-1EFF",  # Latin Extended Additional
+    "U+2000-206F",  # General Punctuation
+    "U+20A0-20CF",  # Currency Symbols
 ]
+
 
 def _parse_unicode_chars(char_list: list[str]) -> list[str]:
     """Parse unicode character definitions including ranges."""
     result = []
     for item in char_list:
-        if item.startswith('U+'):
-            if '-' in item:
+        if item.startswith("U+"):
+            if "-" in item:
                 # Handle range
-                parts = item.replace('U+', '').split('-')
+                parts = item.replace("U+", "").split("-")
                 start = int(parts[0], 16)
                 end = int(parts[1], 16)
                 result.extend([chr(i) for i in range(start, end + 1)])
             else:
                 # Single character
-                result.append(chr(int(item.replace('U+', ''), 16)))
+                result.append(chr(int(item.replace("U+", ""), 16)))
         else:
             if len(item) == 1:
                 result.append(item)
@@ -61,15 +63,14 @@ def _parse_unicode_chars(char_list: list[str]) -> list[str]:
 
     return result
 
+
 COMMON_UNICODE_CHARS = _parse_unicode_chars(UNFORMATTED_COMMON_UNICODE_CHARS)
 
 
 def _hash_font_name(font_name: str, characters: str) -> str:
     font_name = font_name.replace(" ", "").strip()
 
-    hash = base64.urlsafe_b64encode(
-        hashlib.sha256(f"{font_name}_Subset_{characters}".encode('utf-8')).digest()
-    ).decode('utf-8').replace("=", "")
+    hash = base64.urlsafe_b64encode(hashlib.sha256(f"{font_name}_Subset_{characters}".encode("utf-8")).digest()).decode("utf-8").replace("=", "")
 
     # Font names should be at most 31 characters long to work with GDI
     # GDI doesnt distinguish after 31 characters, so hash should go at the beginning
@@ -135,7 +136,7 @@ def subset_fonts(
 
             if not query:
                 danger(f"Font '{style.fontname}' was not found! Did you run collect_fonts?", subset_fonts)
-            
+
             else:
                 if fonts.get(query.font_face) is None:
                     fonts[query.font_face] = {
@@ -143,14 +144,13 @@ def subset_fonts(
                         "names": set(),
                         "names_hashed": {},
                     }
-                
-                fonts[query.font_face]["usage"].update(usage_data.characters_used)
-                
-                for name in query.font_face.exact_names + query.font_face.family_names + [style.fontname]:
-                    value = name if isinstance(name, str) else name.value  
-                    
-                    fonts[query.font_face]["names"].add(value)           
 
+                fonts[query.font_face]["usage"].update(usage_data.characters_used)
+
+                for name in query.font_face.exact_names + query.font_face.family_names + [style.fontname]:
+                    value = name if isinstance(name, str) else name.value
+
+                    fonts[query.font_face]["names"].add(value)
 
     font_replacements: dict[str, str] = {}
 
@@ -228,7 +228,7 @@ def subset_fonts(
 
         new_font_path = source_file.with_stem(f"{source_file.stem}_subset")
 
-        is_collection = len(faces_to_save) > 1 or source_file.suffix.lower() in ('.ttc', '.otc')
+        is_collection = len(faces_to_save) > 1 or source_file.suffix.lower() in (".ttc", ".otc")
         if is_collection:
             ttc = TTCollection()
             for _, f, _ in faces_to_save:
@@ -254,7 +254,6 @@ def subset_fonts(
         for font_face, _, char_count in faces_to_save:
             font_name = _get_fontname(font_face)
             info(f"Subsetted font '{font_name}' ({char_count} glyphs, {sizeof_fmt(old_size)} -> {sizeof_fmt(new_size)})", subset_fonts)
-    
 
     if font_replacements:
         for sub in subs:
@@ -270,26 +269,26 @@ def subset_fonts(
 
                         if data.name in font_replacements:
                             event.text = re.sub(
-                                R'(\\fn[^\\}]*)' + safe_font_name,
-                                lambda m: cast(str, m.group(1)) + font_replacements[data.name],
-                                event.text,
-                                count=1
+                                R"(\\fn[^\\}]*)" + safe_font_name, lambda m: cast(str, m.group(1)) + font_replacements[data.name], event.text, count=1
                             )
                             modified = True
-            
+
             for style in doc.styles:
-                if style.fontname in font_replacements:  
+                if style.fontname in font_replacements:
                     style.fontname = font_replacements[style.fontname]
                     modified = True
-            
+
             if modified:
                 sub._update_doc(doc)
 
             info(f"Updated font names in subfile '{sub.file.name}'", subset_fonts)
-    
+
     if print_final_stats and total_old_size > 0:
-        info(f'Subsetting has saved {sizeof_fmt(total_old_size - total_new_size)} ({(total_old_size - total_new_size) / total_old_size * 100:.2f}%, {sizeof_fmt(total_old_size)} -> {sizeof_fmt(total_new_size)})', subset_fonts)
-    
+        info(
+            f"Subsetting has saved {sizeof_fmt(total_old_size - total_new_size)} ({(total_old_size - total_new_size) / total_old_size * 100:.2f}%, {sizeof_fmt(total_old_size)} -> {sizeof_fmt(total_new_size)})",
+            subset_fonts,
+        )
+
     found_fonts = list[MTFontFile]()
     for r in ["*.[tT][tT][fF]", "*.[oO][tT][fF]", "*.[tT][tT][cC]", "*.[oO][tT][cC]"]:
         for f in get_workdir().glob(r):
@@ -441,7 +440,6 @@ def collect_fonts(
             missing_glyphs = query.font_face.get_missing_glyphs(usage_data.characters_used)
             if len(missing_glyphs) != 0:
                 danger(f"'{fontname}' is missing the following glyphs: {missing_glyphs}", collect_fonts, 3)
-
 
     for r in ["*.[tT][tT][fF]", "*.[oO][tT][fF]", "*.[tT][tT][cC]", "*.[oO][tT][cC]"]:
         for f in get_workdir().glob(r):

--- a/muxtools/subtitle/font.py
+++ b/muxtools/subtitle/font.py
@@ -166,7 +166,7 @@ def subset_fonts(
     for source_file, face_list in faces_by_file.items():
         file_size = os.path.getsize(source_file)
         if file_size < min_file_size_to_subset:
-            debug(f"Skipping subsetting for '{source_file}' ({sizeof_fmt(file_size)} < {sizeof_fmt(min_file_size_to_subset)})", subset_fonts)
+            info(f"Skipping subsetting for '{source_file}' ({sizeof_fmt(file_size)} < {sizeof_fmt(min_file_size_to_subset)})", subset_fonts)
             total_old_size += file_size
             total_new_size += file_size
             continue

--- a/muxtools/subtitle/sub.py
+++ b/muxtools/subtitle/sub.py
@@ -568,6 +568,8 @@ class SubFile(BaseSubFile):
         collect_draw_fonts: bool = True,
         error_missing: bool = False,
         use_ntfs_compliant_names: bool | None = None,
+        subset_fonts: bool = False,
+        subset_default_to_latin: bool = False,
     ) -> list[FontFile]:
         """
         Collects fonts for current subtitle.
@@ -583,6 +585,10 @@ class SubFile(BaseSubFile):
                                             Please use `error_on_danger` in the Setup.
         :param use_ntfs_compliant_names:    Ensure that filenames will work on a NTFS (Windows) filesystem.
                                             The `None` default means it'll use them but only if you're running the script on windows.
+        :param subset_fonts:                Whether or not to subset the fonts to only include the characters used in the subtitle.
+                                            This can greatly reduce the size of the final mux.
+        :param subset_default_to_latin:     If subsetting is enabled and a font has no characters used in the subtitle,
+                                            it will default to a basic latin subset instead of skipping subsetting.
 
         :return:                        A list of FontFile objects
         """
@@ -616,7 +622,7 @@ class SubFile(BaseSubFile):
         if use_ntfs_compliant_names is None:
             use_ntfs_compliant_names = os.name == "nt"
 
-        return collect(self, use_system_fonts, resolved_paths, collect_draw_fonts, error_missing, use_ntfs_compliant_names)
+        return collect(self, use_system_fonts, resolved_paths, collect_draw_fonts, error_missing, use_ntfs_compliant_names, subset_fonts, subset_default_to_latin)
 
     def restyle(self, styles: Style | list[Style], clean_after: bool = True, delete_existing: bool = False, adjust_styles: bool = True) -> Self:
         """

--- a/muxtools/subtitle/sub.py
+++ b/muxtools/subtitle/sub.py
@@ -568,39 +568,23 @@ class SubFile(BaseSubFile):
         collect_draw_fonts: bool = True,
         error_missing: bool = False,
         use_ntfs_compliant_names: bool | None = None,
-        subset_fonts: bool = False,
-        subset_aggressive: bool = False,
-        subset_ignore_fonts_with_no_usage: bool = True,
-        subset_additional_glyphs: list[str] = [],
-        subset_additional_subfiles: list[SubFile] = [],
     ) -> list[FontFile]:
         """
         Collects fonts for current subtitle.
         Note that this places all fonts into the workdir for the episode/Setup and all fonts in it.
 
-        :param use_system_fonts:                    Parses and checks against all installed fonts
-        :param search_current_dir:                  Recursively checks the current work directory for fonts
-        :param additional_fonts:                    Can be a directory or a path to a file directly (or a list of either)
-        :param collect_draw_fonts:                  Whether or not to include fonts used for drawing (usually Arial)
-                                                    See https://github.com/libass/libass/issues/617 for details.
-        :param error_missing:                       Raise an error instead of just warnings when a font is missing.\n
-                                                    This is **deprecated** and will be removed at some point in the future.
-                                                    Please use `error_on_danger` in the Setup.
-        :param use_ntfs_compliant_names:            Ensure that filenames will work on a NTFS (Windows) filesystem.
-                                                    The `None` default means it'll use them but only if you're running the script on windows.
-        :param subset_fonts:                        Whether or not to subset the fonts to only include common glyphs and the characters used in the subtitle.
-                                                    This can greatly reduce the size of the final mux.
-        :param subset_aggressive:                   If subsetting is enabled, this will only include the characters used in the subtitle and any additional glyphs specified.
-                                                    Note: This may harm the re-usability of the font for others editing your subtitle.
-        :param subset_ignore_fonts_with_no_usage:   If subsetting is enabled and no glyphs are used, having this option `True` will skip subsetting for that font.
-                                                    Otherwise, it will use a common glyph subset.
-        :param subset_additional_glyphs:            If you have any additional glyphs that need to be included in the subsetted fonts.
-                                                    You can use the format "U+XXXX" for unicode characters or "U+XXXX-YYYY" for unicode ranges.
-                                                    https://unicode-explorer.com/blocks can help you find the characters/ranges you need.
-        :param subset_additional_subfiles:          If you have other subfiles that need to have font names changed too.
-                                                    Note: Only font names will be edited, no new fonts from these files will be collected.
+        :param use_system_fonts:            Parses and checks against all installed fonts
+        :param search_current_dir:          Recursively checks the current work directory for fonts
+        :param additional_fonts:            Can be a directory or a path to a file directly (or a list of either)
+        :param collect_draw_fonts:          Whether or not to include fonts used for drawing (usually Arial)
+                                            See https://github.com/libass/libass/issues/617 for details.
+        :param error_missing:               Raise an error instead of just warnings when a font is missing.\n
+                                            This is **deprecated** and will be removed at some point in the future.
+                                            Please use `error_on_danger` in the Setup.
+        :param use_ntfs_compliant_names:    Ensure that filenames will work on a NTFS (Windows) filesystem.
+                                            The `None` default means it'll use them but only if you're running the script on windows.
 
-        :return:                                    A list of FontFile objects
+        :return:                        A list of FontFile objects
         """
 
         if not isinstance(additional_fonts, list):
@@ -632,19 +616,7 @@ class SubFile(BaseSubFile):
         if use_ntfs_compliant_names is None:
             use_ntfs_compliant_names = os.name == "nt"
 
-        return collect(
-            self,
-            use_system_fonts,
-            resolved_paths,
-            collect_draw_fonts,
-            error_missing,
-            use_ntfs_compliant_names,
-            subset_fonts,
-            subset_aggressive,
-            subset_ignore_fonts_with_no_usage,
-            subset_additional_glyphs,
-            subset_additional_subfiles
-        )
+        return collect(self, use_system_fonts, resolved_paths, collect_draw_fonts, error_missing, use_ntfs_compliant_names)
 
     def restyle(self, styles: Style | list[Style], clean_after: bool = True, delete_existing: bool = False, adjust_styles: bool = True) -> Self:
         """

--- a/muxtools/utils/convert.py
+++ b/muxtools/utils/convert.py
@@ -22,6 +22,7 @@ __all__: list[str] = [
     "TimeType",
     "ABCTimestamps",
     "RoundingMethod",
+    "sizeof_fmt",
 ]
 
 
@@ -229,3 +230,19 @@ def timedelta_from_formatted(formatted: str) -> timedelta:
     seconds = seconds + (Decimal(split[1]) * Decimal(60))
     seconds = seconds + (Decimal(split[2]))
     return timedelta(seconds=seconds.__float__())
+
+
+def sizeof_fmt(num, suffix="B"):
+    """
+    Human readable file size.
+
+    :param num:        File size in bytes/bits
+    :param suffix:     Suffix to use (change to "b" for bits)
+
+    :return:            Formatted size
+    """
+    for unit in ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"):
+        if abs(num) < 1024.0:
+            return f"{num:3.1f}{unit}{suffix}"
+        num /= 1024.0
+    return f"{num:.1f}Yi{suffix}"

--- a/muxtools/utils/convert.py
+++ b/muxtools/utils/convert.py
@@ -232,17 +232,17 @@ def timedelta_from_formatted(formatted: str) -> timedelta:
     return timedelta(seconds=seconds.__float__())
 
 
-def sizeof_fmt(num, suffix="B"):
+def sizeof_fmt(num, unit="B"):
     """
     Human readable file size.
 
     :param num:        File size in bytes/bits
-    :param suffix:     Suffix to use (change to "b" for bits)
+    :param unit:       Unit to use (change to "b" for bits)
 
-    :return:            Formatted size
+    :return:           Formatted size
     """
-    for unit in ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"):
+    for prefix in ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi", "Ri"):
         if abs(num) < 1024.0:
-            return f"{num:3.1f}{unit}{suffix}"
+            return f"{num:3.1f} {prefix}{unit}"
         num /= 1024.0
-    return f"{num:.1f}Yi{suffix}"
+    return f"{num:.1f}Qi{unit}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "videotimestamps>=1.0.0",
     "typed-ffmpeg-compatible~=3.7.1",
     "mkvinfo~=0.0.3",
-    "typing-extensions>=4.12.0"
+    "typing-extensions>=4.12.0",
+    "fonttools>=4.55.0",
 ]
 classifiers = [
     "Natural Language :: English",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "mkvinfo~=0.0.3",
     "typing-extensions>=4.12.0",
     "fonttools>=4.55.0",
+    "ass-tag-analyzer>=0.0.4"
 ]
 classifiers = [
     "Natural Language :: English",


### PR DESCRIPTION
Edit: Most of this info is incorrect now, see https://github.com/Jaded-Encoding-Thaumaturgy/muxtools/pull/55#issuecomment-3541974560.

----

This new option to `collect_fonts()` allows the user to automatically subset their fonts to reduce the file size of the mux.

It works by using the already available `usage_data` to determine which characters/glyphs have been used.
It then uses fonttools to create a subset of that font, containing only the glyths required.

We return the new font file created instead of the old one.

The `subset_default_to_latin` option is for users to decide whether fonts that are mentioned (in the styles), but not used (typically Arial), are subset using a latin subset (`True`) or are skipped and are not subset (`False`).

None of these changes affect default behaviour, these are opt-in changes.

I've seen storage savings of 99% on one of my fansubbing projects.
Multiply this across 24 episodes, and you're looking at around 1.6GB saved.
<img width="746" height="46" alt="image" src="https://github.com/user-attachments/assets/eea413e4-430d-4f92-90c0-a354cd2a772d" />

Here's a copy of some logs that occur with subsetting enabled.
<img width="848" height="328" alt="image" src="https://github.com/user-attachments/assets/6c906730-2fe7-4d6c-8e33-9ab6297c5604" />

As you can see below, the attachments are renamed to have the suffix `_subset` to indicate that they have a reduced character set.
<img width="951" height="179" alt="image" src="https://github.com/user-attachments/assets/ec221782-b4cd-4e9c-8480-425f8da9dd03" />

Playback works as expected on both devices with and without the original fonts installed.

For scripters to use this, they simply need to update and add the new arguments to `collect_fonts()`:
```py
fonts = sub.collect_fonts(subset_fonts=True, subset_default_to_latin=True)
```