### PR TITLE
SubFile.merge: accept FileMixins

### DIFF
--- a/muxtools/subtitle/sub.py
+++ b/muxtools/subtitle/sub.py
@@ -16,7 +16,7 @@ from .styles import GJM_GANDHI_PRESET, resize_preset
 from .subutils import create_document, dummy_video, has_arch_resampler
 from ..utils.glob import GlobSearch
 from ..utils.download import get_executable
-from ..utils.types import PathLike, TrackType, TimeSourceT, TimeScaleT, TimeScale
+from ..utils.types import FileMixin, PathLike, TrackType, TimeSourceT, TimeScaleT, TimeScale
 from ..utils.log import debug, error, info, warn, log_escape
 from ..utils.convert import resolve_timesource_and_scale
 from ..utils.env import get_temp_workdir, get_workdir, run_commandline
@@ -432,7 +432,7 @@ class SubFile(BaseSubFile):
 
     def merge(
         self,
-        file: PathLike | GlobSearch,
+        file: PathLike | GlobSearch | FileMixin,
         sync: None | int | str = None,
         sync2: None | str = None,
         timesource: TimeSourceT = None,


### PR DESCRIPTION
`SubFile.merge()` can be used with other SubFiles, and tests like `test_mismatching_res_merge` do just that. Really any FileMixin works, as long as it can be parsed as ASS.