### PR TITLE
muxer: Don't duplicate `.mkv` suffix in outfile

### DIFF
--- a/muxtools/muxing/muxer.py
+++ b/muxtools/muxing/muxer.py
@@ -51,9 +51,10 @@ def mux(
     filename, mkvtitle = output_names(tmdb, args, tracklist)
 
     if not outfile:
-        outfile = Path(out_dir, filename)
-        if not outfile.suffix.endswith(".mkv"):
-            outfile.with_suffix(outfile.suffix + ".mkv")
+        if filename.lower().endswith(".mkv"):
+            outfile = Path(out_dir, filename)
+        else:
+            outfile = Path(out_dir, f"{filename}.mkv")
 
     outfile = ensure_path(outfile, "Mux")
 

--- a/muxtools/muxing/muxer.py
+++ b/muxtools/muxing/muxer.py
@@ -51,10 +51,7 @@ def mux(
     filename, mkvtitle = output_names(tmdb, args, tracklist)
 
     if not outfile:
-        if filename.lower().endswith(".mkv"):
-            outfile = Path(out_dir, filename)
-        else:
-            outfile = Path(out_dir, f"{filename}.mkv")
+        outfile = Path(out_dir, filename).with_suffix(".mkv")
 
     outfile = ensure_path(outfile, "Mux")
 

--- a/muxtools/muxing/muxer.py
+++ b/muxtools/muxing/muxer.py
@@ -51,7 +51,9 @@ def mux(
     filename, mkvtitle = output_names(tmdb, args, tracklist)
 
     if not outfile:
-        outfile = Path(out_dir, f"{filename}.mkv")
+        outfile = Path(out_dir, filename)
+        if not outfile.suffix.endswith(".mkv"):
+            outfile.with_suffix(outfile.suffix + ".mkv")
 
     outfile = ensure_path(outfile, "Mux")
 


### PR DESCRIPTION
Setting `out_name` to `example.mkv` in `Setup()` results in a double extension (`example.mkv.mkv`), because the `.mkv` suffix is always appended when muxing.

This PR fixes that behavior by ~~only appending `.mkv` if it isn't already present. Output naming remains unchanged for files with no extension or different extensions~~ always replacing the extension with `.mkv`.