### PR TITLE
SubFile.shift: add `before` and `after` frame boundaries

### DIFF
--- a/muxtools/subtitle/basesub.py
+++ b/muxtools/subtitle/basesub.py
@@ -242,19 +242,31 @@ class BaseSubFile(ABC, MuxingFile):
         return ShiftResult(new_line, outofbounds)
 
     def _shift_line_by_frames(
-        self, line: _Line, offset: int, timestamps: ABCTimestamps, oob_mode: OutOfBoundsMode = OutOfBoundsMode.ERROR
+        self,
+        line: _Line,
+        offset: int,
+        timestamps: ABCTimestamps,
+        oob_mode: OutOfBoundsMode = OutOfBoundsMode.ERROR,
+        before: int | None = None,
+        after: int | None = None,
     ) -> ShiftResult:
         outofbounds = False
         start_frame = timestamps.time_to_frame(int(line.start.total_seconds() * 1000), TimeType.START, 3)
-        new_start_frame = start_frame + offset
 
         end_ms = int(line.end.total_seconds() * 1000)
         if end_ms <= timestamps.first_timestamps:
-            end_frame = new_start_frame
+            end_frame = start_frame
         else:
             end_frame = timestamps.time_to_frame(end_ms, TimeType.END, 3)
 
-        new_end_frame = end_frame + offset
+        shift_all = before is None and after is None
+
+        shift_start = shift_all or (before is not None and start_frame <= before) or (after is not None and start_frame >= after)
+
+        shift_end = shift_all or (before is not None and end_frame <= before) or (after is not None and end_frame >= after)
+
+        new_start_frame = start_frame + offset if shift_start else start_frame
+        new_end_frame = end_frame + offset if shift_end else end_frame
 
         if new_start_frame < 0 or new_end_frame < 0:
             outofbounds = True

--- a/muxtools/subtitle/sub.py
+++ b/muxtools/subtitle/sub.py
@@ -826,22 +826,26 @@ class SubFile(BaseSubFile):
         timesource: TimeSourceT = None,
         timescale: TimeScaleT = None,
         oob_mode: OutOfBoundsMode = OutOfBoundsMode.ERROR,
+        before: int | None = None,
+        after: int | None = None,
     ) -> Self:
         """
         Shifts all lines by any frame number.
 
-        :param frames:              Number of frames to shift by
+        :param frames:              Number of frames to shift by.
         :param timesource:          The source of timestamps/timecodes. For details check the docstring on the type.
         :param timescale:           Unit of time (in seconds) in terms of which frame timestamps are represented.\n
                                     For details check the docstring on the type.
         :param oob_mode:            What to do with lines that are out of bounds after shifting.
+        :param before:              Only shift timestamps before or equal to this frame number.
+        :param after:               Only timestamps after or equal to this frame number.
         """
         resolved_ts = resolve_timesource_and_scale(timesource, timescale, fetch_from_setup=True, caller=self)
 
         def shift_lines(lines: LINES):
             new_list = list[_Line]()
             for line in lines:
-                line_result = self._shift_line_by_frames(line, frames, resolved_ts, oob_mode)
+                line_result = self._shift_line_by_frames(line, frames, resolved_ts, oob_mode, before, after)
 
                 if line_result.was_out_of_bounds:
                     warn(f"Line is out of bounds: {line.start} - {line.end}:\n\t{line.text}", self)


### PR DESCRIPTION
This allows for finer control over subtitle shifts, and lets users easily fix mid-episode desyncs.