### PR TITLE
Move imports to function scope to optimize import time

### DIFF
--- a/muxtools/muxing/muxer.py
+++ b/muxtools/muxing/muxer.py
@@ -2,7 +2,6 @@ from shlex import join as joincommand
 from shutil import rmtree
 from pathlib import Path
 import subprocess
-import wget  # type: ignore[import-untyped]
 import re
 import os
 
@@ -194,6 +193,8 @@ def output_names(
             title = clean_name(re.sub(re.escape(R"$title$"), "", title))
 
     if tmdb:
+        import wget  # type: ignore[import-untyped]
+
         debug("Fetching tmdb metadata...", "Mux")
         mediameta = tmdb.get_media_meta()
         epmeta = tmdb.get_episode_meta(epint) if not tmdb.movie else None

--- a/muxtools/muxing/tmdb.py
+++ b/muxtools/muxing/tmdb.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass, field
 from enum import IntEnum
 from pathlib import Path
 from typing import cast
-import requests
 import logging
 
 from ..utils.log import debug, error, info
@@ -111,6 +110,8 @@ class TmdbConfig:
         return self.write_ids or self.write_date or self.write_title or self.write_summary or self.write_synopsis
 
     def get_media_meta(self) -> MediaMetadata:
+        import requests
+
         url = f"{BASE_URL}/{'movie' if self.movie else 'tv'}/{self.id}?language={self.language}"
         headers = {"accept": "application/json", "Authorization": f"Bearer {API_KEY}"}
         response = requests.get(url, headers=headers)
@@ -135,6 +136,8 @@ class TmdbConfig:
         )
 
     def get_episode_meta(self, num: int) -> EpisodeMetadata:
+        import requests
+
         if not hasattr(self, "episodes"):
             headers = {"accept": "application/json", "Authorization": f"Bearer {API_KEY}"}
             if self.order:

--- a/muxtools/subtitle/font.py
+++ b/muxtools/subtitle/font.py
@@ -4,13 +4,12 @@ import shutil
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import TypedDict, cast
-from font_collector import ABCFontFace, VariableFontFace
-from fontTools.subset import Subsetter  # type: ignore[import-untyped]
-from fontTools import ttLib  # type: ignore[import-untyped]
-from fontTools.ttLib.ttCollection import TTCollection  # type: ignore[import-untyped]
+from typing import TYPE_CHECKING, TypedDict, cast
 import hashlib
 import base64
+
+if TYPE_CHECKING:
+    from font_collector import ABCFontFace
 
 from .sub import SubFile, FontFile as MTFontFile
 from ..utils.convert import sizeof_fmt
@@ -117,6 +116,9 @@ def subset_fonts(
 
     set_loglevel(logging.CRITICAL)
 
+    from fontTools.subset import Subsetter  # type: ignore[import-untyped]
+    from fontTools import ttLib  # type: ignore[import-untyped]
+    from fontTools.ttLib.ttCollection import TTCollection  # type: ignore[import-untyped]
     from font_collector import AssDocument, FontLoader, FontCollection, FontSelectionStrategyLibass, ABCFontFace
 
     from ass_tag_analyzer import parse_line, AssValidTagFontName  # type: ignore[import-untyped]
@@ -372,6 +374,8 @@ def _weight_to_name(weight: int) -> str | int:
 
 
 def _get_fontname(font: ABCFontFace) -> str:
+    from font_collector import VariableFontFace
+
     filename_fallback = False
     try:
         found = font.get_family_name_from_lang("en")
@@ -424,7 +428,7 @@ def collect_fonts(
 
     set_loglevel(logging.CRITICAL)
 
-    from font_collector import AssDocument, FontLoader, FontCollection, FontSelectionStrategyLibass, ABCFontFace
+    from font_collector import AssDocument, FontLoader, FontCollection, FontSelectionStrategyLibass, ABCFontFace, VariableFontFace
 
     font_collection = FontCollection(
         use_system_fonts, additional_fonts=FontLoader.load_additional_fonts(additional_fonts, scan_subdirs=True) if additional_fonts else []

--- a/muxtools/subtitle/sub.py
+++ b/muxtools/subtitle/sub.py
@@ -17,7 +17,7 @@ from .subutils import create_document, dummy_video, has_arch_resampler
 from ..utils.glob import GlobSearch
 from ..utils.download import get_executable
 from ..utils.types import FileMixin, PathLike, TrackType, TimeSourceT, TimeScaleT, TimeScale
-from ..utils.log import debug, error, info, warn, log_escape
+from ..utils.log import debug, error, info, warn
 from ..utils.convert import resolve_timesource_and_scale
 from ..utils.env import get_temp_workdir, get_workdir, run_commandline
 from ..utils.files import ensure_path_exists, make_output, clean_temp_files, uniquify_path, ensure_path
@@ -265,6 +265,8 @@ class SubFile(BaseSubFile):
         backslash = "\\"  # This is to ensure support for previous python versions that don't allow backslashes in f-strings.
 
         def _do_autoswap(lines: LINES):
+            from rich.markup import escape as log_escape
+
             for i, line in enumerate(lines):
                 if not allowed_styles or name_matches_style(str(line.style), allowed_styles, exact_names):
                     to_swap: dict = {}

--- a/muxtools/utils/download.py
+++ b/muxtools/utils/download.py
@@ -4,7 +4,6 @@ from .log import crit, error, info
 from .files import ensure_path_exists
 
 import os
-import wget  # type: ignore[import-untyped]
 import shutil as sh
 from pathlib import Path
 from dataclasses import dataclass
@@ -105,6 +104,8 @@ def _append_exe_to_path(file: PathLike) -> None:
 
 
 def download_binary(type: str) -> str:
+    import wget  # type: ignore[import-untyped]
+
     if os.name != "nt":
         raise EnvironmentError("Of course only Windows is supported for downloading of binaries!")
 

--- a/muxtools/utils/formats.py
+++ b/muxtools/utils/formats.py
@@ -1,7 +1,9 @@
 import re
 from enum import Enum
-from typing import Any, Optional
-from typed_ffmpeg.ffprobe.schema import streamType
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from typed_ffmpeg.ffprobe.schema import streamType
 
 __all__ = ["AudioFormat"]
 
@@ -58,6 +60,8 @@ class AudioFormat(Enum):
         return False
 
     def __eq__(self, value: Any) -> bool:
+        from typed_ffmpeg.ffprobe.schema import streamType
+
         if isinstance(value, streamType):
             profile_matches = bool(value.profile and self.profile and self.profile.casefold() == value.profile.casefold())
             if self.profile and not profile_matches:

--- a/muxtools/utils/language_util.py
+++ b/muxtools/utils/language_util.py
@@ -1,5 +1,7 @@
-from langcodes import Language, standardize_tag as stdz_tag
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from langcodes import Language
 
 from .log import error
 
@@ -7,6 +9,8 @@ __all__ = ["standardize_tag"]
 
 
 def standardize_tag(lang: str, caller: Any | None = None) -> tuple[Language, str]:
+    from langcodes import Language, standardize_tag as stdz_tag
+
     standardized = stdz_tag(lang)
     language = Language.get(standardized)
 

--- a/muxtools/utils/probe.py
+++ b/muxtools/utils/probe.py
@@ -1,12 +1,13 @@
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional, Callable
-from typed_ffmpeg import probe_obj
-from typed_ffmpeg.ffprobe.schema import streamType, ffprobeType, tagsType, formatType
+from typing import TYPE_CHECKING, Any, Optional, Callable
 from mkvinfo import MKVInfo, Track as MkvInfoTrack, Container as MkvInfoContainer
 from itertools import groupby
-from langcodes import Language
+
+if TYPE_CHECKING:
+    from typed_ffmpeg.ffprobe.schema import streamType, ffprobeType, tagsType, formatType
+    from langcodes import Language
 
 from .log import error, warn
 from .types import PathLike, TrackType
@@ -79,6 +80,8 @@ class TrackInfo:
 
     @property
     def sanitized_lang(self) -> Language:
+        from langcodes import Language
+
         if self.raw_mkvmerge and (bool(self.raw_mkvmerge.properties.language_ietf) or bool(self.raw_mkvmerge.properties.language)):
             if self.raw_mkvmerge.properties.language_ietf:
                 return Language.get(self.raw_mkvmerge.properties.language_ietf)
@@ -120,6 +123,8 @@ class ParsedFile:
         :param allow_mkvmerge_warning:  If the warning for a missing mkvmerge install should actually be printed.\n
                                         Again, for internal use.
         """
+        from typed_ffmpeg import probe_obj
+
         path = ensure_path_exists(path, caller)
         ffprobe_exe = get_executable("ffprobe")
         try:

--- a/muxtools/utils/subprogress.py
+++ b/muxtools/utils/subprogress.py
@@ -3,7 +3,6 @@ from math import ceil
 from datetime import timedelta
 from re import Pattern, compile
 from dataclasses import dataclass
-from rich.progress import Progress, TextColumn, BarColumn, TaskProgressColumn, TimeRemainingColumn, TimeElapsedColumn
 from shlex import split as splitcmd
 from subprocess import Popen, PIPE, STDOUT
 
@@ -25,6 +24,8 @@ class ProgressBarConfig:
 
 
 def run_cmd_pb(cmd: str | list[str], silent: bool = True, pbc: ProgressBarConfig = ProgressBarConfig(), **kwargs: Any) -> int:
+    from rich.progress import Progress, TextColumn, BarColumn, TaskProgressColumn, TimeRemainingColumn, TimeElapsedColumn
+
     args = splitcmd(cmd) if isinstance(cmd, str) else cmd
     process = Popen(args, stdout=PIPE, stderr=STDOUT, text=True, encoding="UTF-8", errors="ignore", bufsize=1, **kwargs)
     if not pbc.regex:


### PR DESCRIPTION
Reduce import time of `import muxtools` from ~500ms to less than 200 ms