### PR TITLE
log: defer rich setup and strip markup when externally handled

### DIFF
--- a/muxtools/utils/log.py
+++ b/muxtools/utils/log.py
@@ -1,33 +1,120 @@
 import logging
-from rich.logging import RichHandler
-from rich.console import Console
-from rich.theme import Theme
-from rich.markup import escape as log_escape
-from typing import Any
+import re
+import sys
 import time
+from typing import Any
 
-__all__ = ["crit", "debug", "error", "exit", "info", "warn", "logger", "danger", "LoggingException", "log_escape"]
+__all__ = [
+    "crit",
+    "debug",
+    "error",
+    "exit",
+    "info",
+    "warn",
+    "logger",
+    "danger",
+    "LoggingException",
+    "setup_logging",
+    "log_escape",
+]
+
+logging.addLevelName(35, "DANGER")
+logging.addLevelName(logging.WARNING, "WARN")
+
+logger = logging.getLogger("muxtools")
+logger.addHandler(logging.NullHandler())
 
 
 class LoggingException(Exception):
     """Custom exception returned from log.crit and log.error"""
 
 
-FORMAT = "%(name)s | %(message)s"  #
-console = Console(theme=Theme({"logging.level.warn": "gold3", "logging.level.danger": "red"}))
-logging.basicConfig(format=FORMAT, datefmt="[%X]", handlers=[RichHandler(markup=True, omit_repeated_times=False, show_path=False, console=console)])
+def log_escape(text: str) -> str:
+    from rich.markup import escape
 
-logging.addLevelName(logging.WARNING, "WARN")
-logging.addLevelName(35, "DANGER")
-logger = logging.getLogger("muxtools")
-logger.setLevel(logging.DEBUG)
+    return escape(text)
+
+
+def setup_logging(force: bool = False) -> None:
+    if not force and _has_active_handlers(logger):
+        return
+
+    from rich.console import Console
+    from rich.logging import RichHandler
+    from rich.theme import Theme
+
+    format_str = "%(name)s | %(message)s"
+    console = Console(theme=Theme({"logging.level.warn": "gold3", "logging.level.danger": "red"}))
+    handler = RichHandler(markup=True, omit_repeated_times=False, show_path=False, console=console)
+    handler.setFormatter(logging.Formatter(format_str, datefmt="[%X]"))
+
+    logger.handlers = [h for h in logger.handlers if not isinstance(h, (logging.NullHandler, handler.__class__))]
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+
+
+def _has_active_handlers(log: logging.Logger) -> bool:
+    curr: logging.Logger | None = log
+    while curr:
+        if any(not isinstance(h, logging.NullHandler) for h in curr.handlers):
+            return True
+        if not curr.propagate:
+            break
+        curr = curr.parent
+    return False
+
+
+def _is_rich_active() -> bool:
+    if "rich.logging" not in sys.modules:
+        return False
+
+    from rich.logging import RichHandler
+
+    curr: logging.Logger | None = logger
+    while curr:
+        if any(isinstance(h, RichHandler) and getattr(h, "markup", False) for h in curr.handlers):
+            return True
+        if not curr.propagate:
+            break
+        curr = curr.parent
+    return False
+
+
+def _ensure_logging() -> None:
+    if not _has_active_handlers(logger):
+        setup_logging()
+
+
+def _strip_markup(msg: str) -> str:
+    try:
+        from rich.text import Text
+
+        return Text.from_markup(msg).plain
+    except Exception:
+        return re.sub(r"\[/?(?:[a-zA-Z#/@][^]]*?)\]", "", msg)
 
 
 def _format_msg(msg: str, caller: Any) -> str:
-    if caller and not isinstance(caller, str):
-        caller = caller.__class__.__qualname__ if hasattr(caller, "__class__") and caller.__class__.__name__ not in ["function", "method"] else caller
-        caller = caller.__name__ if not isinstance(caller, str) else caller
-    return msg if caller is None else f"[bold]{caller}:[/] {msg}"
+    _ensure_logging()
+
+    if caller is not None and not isinstance(caller, str):
+        if isinstance(caller, type):
+            caller = caller.__qualname__
+        elif hasattr(caller, "__class__") and caller.__class__.__name__ not in ("function", "method"):
+            caller = caller.__class__.__qualname__
+        elif hasattr(caller, "__qualname__"):
+            caller = caller.__qualname__
+        elif hasattr(caller, "__name__"):
+            caller = caller.__name__
+        else:
+            caller = str(caller)
+
+    if _is_rich_active():
+        return msg if caller is None else f"[bold]{caller}:[/] {msg}"
+
+    plain_msg = _strip_markup(msg)
+    return plain_msg if caller is None else f"{caller}: {plain_msg}"
 
 
 def crit(msg: str, caller: Any = None) -> LoggingException:
@@ -79,6 +166,5 @@ def error(msg: str, caller: Any = None) -> LoggingException:
 def exit(msg: str, caller: Any = None):
     message = _format_msg(msg, caller)
     logger.info(message)
-    import sys
 
     sys.exit(0)


### PR DESCRIPTION
- Defer setup_logging to runtime to avoid eager rich imports at module load
- Keep rich handlers optional so muxtools respects external logging configs
- Safely strip rich markup when non-rich handlers are active
- Lazily import rich in log_escape and caller formatting
